### PR TITLE
(experimental) Replace cookie-parser with cookie-session

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3134,26 +3134,29 @@
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.0.tgz",
       "integrity": "sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg=="
     },
-    "cookie-parser": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.4.tgz",
-      "integrity": "sha512-lo13tqF3JEtFO7FyA49CqbhaFkskRJ0u/UAiINgrIXeRCY41c88/zxtrECl8AKH3B0hj9q10+h3Kt8I7KlW4tw==",
+    "cookie-session": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/cookie-session/-/cookie-session-1.3.3.tgz",
+      "integrity": "sha512-GrMdrU1YTQWtmVTo0Rj3peeZRMc2xJrBslFYtZcYTo+hrSLmrcf69OrRkDi84xTfylgCy2wgpRHyY4le6lE5+A==",
       "requires": {
-        "cookie": "0.3.1",
-        "cookie-signature": "1.0.6"
-      },
-      "dependencies": {
-        "cookie": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-        }
+        "cookies": "0.7.3",
+        "debug": "2.6.9",
+        "on-headers": "~1.0.2"
       }
     },
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
+    },
+    "cookies": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.7.3.tgz",
+      "integrity": "sha512-+gixgxYSgQLTaTIilDHAdlNPZDENDQernEMiIcZpYYP14zgHsCt4Ce1FEjFtcp6GefhozebB6orvhAAWx/IS0A==",
+      "requires": {
+        "depd": "~1.1.2",
+        "keygrip": "~1.0.3"
+      }
     },
     "copy-concurrently": {
       "version": "1.0.5",
@@ -6572,6 +6575,11 @@
         "verror": "1.10.0"
       }
     },
+    "keygrip": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/keygrip/-/keygrip-1.0.3.tgz",
+      "integrity": "sha512-/PpesirAIfaklxUzp4Yb7xBper9MwP6hNRA6BGGUFCgbJ+BM5CKBtsoxinNXkLHAr+GXS1/lSlF2rP7cv5Fl+g=="
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -7972,6 +7980,11 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+      "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
     },
     "once": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@kth/canvas-api": "^2.1.0",
     "body-parser": "^1.19.0",
     "bunyan": "^1.8.12",
-    "cookie-parser": "^1.4.4",
+    "cookie-session": "^1.3.3",
     "cuid": "^2.1.6",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",

--- a/server/authorization.js
+++ b/server/authorization.js
@@ -3,15 +3,13 @@ const isAllowed = require('../lib/is-allowed')
 const { ClientError } = require('../lib/errors')
 
 async function authorize (req, res, next) {
-  const accessData = req.accessData || req.signedCookies.access_data
-  const courseId = req.query.course_id || req.body.course_id
-
-  req.accessData = accessData
+  const accessData = req.session
+  const courseId = req.body.course_id || req.query.course_id
 
   if (!accessData) {
     throw new Error('No access data found')
   }
-  
+
   // TODO: this should be !== to work!
   if (accessData.realUserId && accessData.userId === accessData.realUserId) {
     throw new ClientError(
@@ -50,11 +48,10 @@ async function authorize (req, res, next) {
 async function setAdminCookie (req, res, next) {
   log.fatal('You are setting the admin token in a Cookie!!!!')
 
-  res.cookie(
-    'access_data',
-    { token: process.env.CANVAS_ADMIN_API_TOKEN },
-    { signed: true }
-  )
+  req.session = {
+    token: process.env.CANVAS_ADMIN_API_TOKEN
+  }
+
   next()
 }
 

--- a/server/index.js
+++ b/server/index.js
@@ -4,7 +4,7 @@ const Router = require('express-promise-router')
 const log = require('skog')
 const path = require('path')
 const bodyParser = require('body-parser')
-const cookieParser = require('cookie-parser')
+const cookieSession = require('cookie-session')
 const system = require('./system')
 const { oauth1, oauth2 } = require('./oauth')('/export3')
 const authorization = require('./authorization')
@@ -19,13 +19,20 @@ const {
 const cuid = require('cuid')
 
 const server = express()
+server.use(cookieSession({
+  name: 'session',
+  secret: process.env.COOKIE_SIGNATURE_SECRET,
+  secureProxy: process.env.NODE_ENV !== 'development',
+  signed: true,
+  name: 'session'
+}))
+
 server.set('views', __dirname + '/views')
 server.engine('handlebars', expressHandlebars())
 server.set('view engine', 'handlebars')
 
 server.use(bodyParser.json())
 server.use(bodyParser.urlencoded({ extended: true }))
-server.use(cookieParser(process.env.COOKIE_SIGNATURE_SECRET))
 
 server.use((req, res, next) => {
   log.child({ req_id: cuid() }, next)

--- a/server/oauth.js
+++ b/server/oauth.js
@@ -110,8 +110,7 @@ const oauth2 = redirectPath =>
       req.query.code
     )
 
-    req.accessData = accessData
-    res.cookie('access_data', accessData, { signed: true })
+    req.session = accessData
     next()
   }
 


### PR DESCRIPTION
An attempt of replacing cookie-parser with `cookie-session`.

The rationale behind this PR is to use a more "opinionated" package for handling sessions rather than a "general" package for handling cookies.