### PR TITLE
Submit what you see

### DIFF
--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -1,5 +1,6 @@
 const CanvasAPI = require('@kth/canvas-api')
 const log = require('skog')
+const memoizee = require('memoizee')
 
 async function getAssignments (token, courseId) {
   const canvas = CanvasAPI(`${process.env.CANVAS_HOST}/api/v1`, token)
@@ -29,7 +30,7 @@ async function getSelfEnrollments (token, courseId) {
     .toArray()
 }
 
-async function getSubmissions (token, courseId, assignmentId) {
+async function getSubmissionsWithoutCache (token, courseId, assignmentId) {
   log.debug(
     `Getting submissions for course ${courseId} - assignment ${assignmentId}`
   )
@@ -47,6 +48,10 @@ async function getGrade (submissions, studentIntegrationId) {
 
   return submission && submission.grade
 }
+
+const getSubmissions = memoizee(getSubmissionsWithoutCache, {
+  maxAge: 15 * 60 * 1000
+})
 
 module.exports = {
   getCourse,

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -50,7 +50,7 @@ async function getGrade (submissions, studentIntegrationId) {
 }
 
 const getSubmissions = memoizee(getSubmissionsWithoutCache, {
-  maxAge: 15 * 60 * 1000
+  maxAge: 60 * 60 * 1000
 })
 
 module.exports = {


### PR DESCRIPTION
This PR changes the app in a way that will send to Ladok the grades displayed to the user previously.

There are two solutions for this:

1. The adopted solution (cache submissions obtained from Canvas in the server). Cache is hit only if submissions are requested to the **same course** and with the **same token (a.k.a. same session)**
2. The alternative solution (send grades from the browser).

I've implemented solution 1 considering:

- 👎 It's *slightly* less reliable than 2. For example, if the server goes down, cache will not hit.
- 👍 It's *way* more easy to implement
- 👍 It works when a user clicks "export" before the table has been loaded. (do we want this feature?)