### PR TITLE
Fix react render warning

### DIFF
--- a/client/index.scss
+++ b/client/index.scss
@@ -2,11 +2,13 @@
 
 html {
   font-family: $sansSerif;
+  height: 100%;
 }
 
 body {
   background: $white;
   color: $black;
+  height: 100%;
   margin: 0;
   padding: $spacing;
 }
@@ -43,6 +45,90 @@ body {
   place-self: flex-end;
 }
 
+table {
+  display: flex;
+  flex-flow: column;
+  height: 100%;
+  width: 100%;
+}
+
+table thead {
+  /* head takes the height it requires,
+  and it's not scaled when table is resized */
+  flex: 0 0 auto;
+  width: calc(100% - 0.9em);
+}
+
+table tbody {
+  /* body takes all the remaining available space */
+  flex: 1 1 auto;
+  display: block;
+  overflow-y: scroll;
+}
+
+table tbody tr {
+  width: 100%;
+}
+
+table thead,
+table tbody tr {
+  display: table;
+  table-layout: fixed;
+}
+
+#root {
+  display: flex;
+  flex-flow: column;
+  height: 100%;
+  max-height: 100%;
+}
+
+#root > form {
+  flex-grow: 1;
+  display: flex;
+  flex-flow: column;
+  height: 100%;
+  max-height: 100%;
+}
+
+.table-container {
+  height: 10em;
+  flex: 1 1 10em;
+  overflow: hidden;
+}
+
+table {
+  margin-bottom: 14px;
+  margin: 0;
+}
+
+caption {
+  padding: 0em;
+}
+
+table caption {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+h2 {
+  margin: 0px;
+}
+
+.alert,
+.alert-success {
+  flex: 0 0 auto;
+  font-size: 1em;
+}
+
+.success-h2 {
+  margin-top: 1em;
+}
+
+.select-wrapper {
+  margin-bottom: 2em;
+}
+
 /* Loading Spinner, courtesy of lukehaas (https://github.com/lukehaas/css-loaders) */
 .loader,
 .loader:after {
@@ -65,7 +151,6 @@ body {
   animation: load8 1.1s infinite linear;
 }
 
-
 @keyframes load8 {
   0% {
     transform: rotate(0deg);
@@ -73,83 +158,4 @@ body {
   100% {
     transform: rotate(360deg);
   }
-}
-
-
-table {
-    display: flex;
-    flex-flow: column;
-    height: 100%;
-    width: 100%;
-}
-table thead {
-    /* head takes the height it requires, 
-    and it's not scaled when table is resized */
-    flex: 0 0 auto;
-    width: calc(100% - 0.9em);
-}
-table tbody {
-    /* body takes all the remaining available space */
-    flex: 1 1 auto;
-    display: block;
-    overflow-y: scroll;
-}
-table tbody tr {
-    width: 100%;
-}
-table thead, table tbody tr {
-    display: table;
-    table-layout: fixed;
-}
-
-
-#root {
- display: flex;
- flex-flow: column;
- height: 100%;
- max-height: 100%;
-}
-html {
- height: 100%;
-}
-#root > form {
- flex-grow: 1;
- display: flex;
- flex-flow: column;
- height: 100%;
- max-height: 100%;
-}
-
-.table-container {
- height: 10em;
- flex: 1 1 10em;
- overflow: hidden;
-}
-table {
- margin-bottom: 14px;
- margin: 0;
-}
-caption {
-  padding: 0em;
-}
-table caption {
- margin-top: 0px;
- margin-bottom: 0px;
-}
-
-h2 {
-  margin: 0px;
-}
-
-.alert, .alert-success {
- flex: 0 0 auto;
-  font-size: 1em;
-}
-
-.success-h2 {
-  margin-top: 1em;
-}
-
-.select-wrapper {
-  margin-bottom: 2em;
 }

--- a/server/views/form.handlebars
+++ b/server/views/form.handlebars
@@ -7,7 +7,8 @@
   <title>Export to Ladok</title>
   <link rel="stylesheet" type="text/css" href="{{prefix_path}}/dist/index.css">
 </head>
-<body id="root">
+<body>
+  <div id="root"></div>
   <script>
     window.__COURSE_ID__ = '{{course_id}}'
   </script>


### PR DESCRIPTION
I noticed we were getting a warning from React about rendering straight to the body element. It was recommended to move it to a div.

See more here: https://stackoverflow.com/questions/49876866/rendering-components-directly-warning

Had to slightly adjust the css to make the scrollable table of students work. There are lots of "changes" but it is mostly me moving the spinner stuff to the bottom and spacing things out evenly.