### PR TITLE
Filter out students with grades that have been certified.

### DIFF
--- a/lib/ladok/index.js
+++ b/lib/ladok/index.js
@@ -3,6 +3,20 @@ const log = require('skog')
 const memoizee = require('memoizee')
 const { ExportError } = require('../errors')
 
+/** Filter out the students with "SenastAttesteradeResultat"
+ * from a "studieresultat sok" response related to a module */
+function filterOutStudentsWithAttesteradeResultat (response, moduleId) {
+  return response.filter(studyResult => {
+    return !studyResult.ResultatPaUtbildningar.find(educationResult => {
+      return (
+        educationResult.SenastAttesteradeResultat &&
+        educationResult.SenastAttesteradeResultat.UtbildningsinstansUID ===
+          moduleId
+      )
+    })
+  })
+}
+
 /** Get the "ArbetsUnderlag" of a "Ladok Resultat" related to a module */
 function getArbetsUnderlag (result, moduleId) {
   const underlag = result.ResultatPaUtbildningar.map(rpu => rpu.Arbetsunderlag)
@@ -86,16 +100,7 @@ async function listGradeableResults (sectionId, moduleId) {
     )
     .toArray()
 
-  //Note: Filter out "Resultat" that already have been certified in Ladok.
-  const filteredResponse = response.filter(studyResult => {
-    return !studyResult.ResultatPaUtbildningar.find(educationResult => {
-      return (
-        educationResult.SenastAttesteradeResultat &&
-        educationResult.SenastAttesteradeResultat.KurstillfalleUID === sectionId
-      )
-    })
-  })
-  return filteredResponse
+  return filterOutStudentsWithAttesteradeResultat(response, moduleId)
 }
 
 /** Returns a blank "Draft" object that can be sent to ladok */

--- a/lib/ladok/index.js
+++ b/lib/ladok/index.js
@@ -3,25 +3,24 @@ const log = require('skog')
 const memoizee = require('memoizee')
 const { ExportError } = require('../errors')
 
-/** Filter out the students with "SenastAttesteradeResultat"
- * from a "studieresultat sok" response related to a module */
-function filterOutStudentsWithAttesteradeResultat (response, moduleId) {
-  return response.filter(studyResult => {
-    return !studyResult.ResultatPaUtbildningar.find(educationResult => {
-      return (
-        educationResult.SenastAttesteradeResultat &&
-        educationResult.SenastAttesteradeResultat.UtbildningsinstansUID ===
-          moduleId
-      )
-    })
-  })
+/** Get the "AttesteradeResultat" of a "Ladok Resultat" related to a module */
+function hasAttesteradeResultat (result, moduleId) {
+  return result.ResultatPaUtbildningar.find(
+    rpu =>
+      rpu.SenastAttesteradeResultat &&
+      rpu.SenastAttesteradeResultat.UtbildningsinstansUID === moduleId
+  )
 }
 
 /** Get the "ArbetsUnderlag" of a "Ladok Resultat" related to a module */
 function getArbetsUnderlag (result, moduleId) {
-  const underlag = result.ResultatPaUtbildningar.map(rpu => rpu.Arbetsunderlag)
+  const r = result.ResultatPaUtbildningar.find(
+    rpu =>
+      rpu.Arbetsunderlag &&
+      rpu.Arbetsunderlag.UtbildningsinstansUID === moduleId
+  )
 
-  return underlag.find(au => au && au.UtbildningsinstansUID === moduleId)
+  return r && r.Arbetsunderlag
 }
 
 /** Get all "Betygskalor" in Ladok without caching */
@@ -86,7 +85,8 @@ async function listGradeableResults (sectionId, moduleId) {
   log.debug(
     `Getting gradeable results for section ${sectionId} - module ${moduleId}`
   )
-  const response = await ladokApi
+
+  const result = await ladokApi
     .sok(
       `/resultat/studieresultat/rapportera/utbildningsinstans/${moduleId}/sok`,
       {
@@ -100,7 +100,7 @@ async function listGradeableResults (sectionId, moduleId) {
     )
     .toArray()
 
-  return filterOutStudentsWithAttesteradeResultat(response, moduleId)
+  return result.filter(r => !hasAttesteradeResultat(r, moduleId))
 }
 
 /** Returns a blank "Draft" object that can be sent to ladok */

--- a/lib/ladok/index.js
+++ b/lib/ladok/index.js
@@ -72,7 +72,7 @@ async function listGradeableResults (sectionId, moduleId) {
   log.debug(
     `Getting gradeable results for section ${sectionId} - module ${moduleId}`
   )
-  return ladokApi
+  const response = await ladokApi
     .sok(
       `/resultat/studieresultat/rapportera/utbildningsinstans/${moduleId}/sok`,
       {
@@ -85,6 +85,17 @@ async function listGradeableResults (sectionId, moduleId) {
       'Resultat'
     )
     .toArray()
+
+  //Note: Filter out "Resultat" that already have been certified in Ladok.
+  const filteredResponse = response.filter(studyResult => {
+    return !studyResult.ResultatPaUtbildningar.find(educationResult => {
+      return (
+        educationResult.SenastAttesteradeResultat &&
+        educationResult.SenastAttesteradeResultat.KurstillfalleUID === sectionId
+      )
+    })
+  })
+  return filteredResponse
 }
 
 /** Returns a blank "Draft" object that can be sent to ladok */


### PR DESCRIPTION
Implementation based on the assumption from the Trello card i.e. that results containing `SenastAttesteradeResultat` have already been certified.

One think I noticed is that some of the `SenastAttesteradeResultat` might not have the correct `KurstillfalleUID`, thus I ignore those. Since I don't have the correct permissions in Ladok right now, I've had a hard time verifying that this works 100% yet.