### PR TITLE
Remove <form>

### DIFF
--- a/client/WizardConfirm.js
+++ b/client/WizardConfirm.js
@@ -52,7 +52,7 @@ function WizardConfirm ({
   )
 
   return (
-    <form>
+    <div>
       <h2>Transfer grades (Step 2 of 2)</h2>
       <p>
         The list below represents what the application will transfer from Canvas
@@ -76,7 +76,7 @@ function WizardConfirm ({
         />
       )}
       {showTable && tableFooter}
-    </form>
+    </div>
   )
 }
 

--- a/client/WizardConfirm.js
+++ b/client/WizardConfirm.js
@@ -52,7 +52,7 @@ function WizardConfirm ({
   )
 
   return (
-    <div>
+    <div className='form'>
       <h2>Transfer grades (Step 2 of 2)</h2>
       <p>
         The list below represents what the application will transfer from Canvas

--- a/client/index.scss
+++ b/client/index.scss
@@ -83,7 +83,7 @@ table tbody tr {
   max-height: 100%;
 }
 
-#root > form {
+#root > .form {
   flex-grow: 1;
   display: flex;
   flex-flow: column;


### PR DESCRIPTION
This prevents the "form" to be submitted making a GET request to "itself" which causes "Missing parameter" errors.