### PR TITLE
Using admin token to get grading standards.

### DIFF
--- a/.env.in
+++ b/.env.in
@@ -15,6 +15,8 @@ CANVAS_HOST=https://kth.test.instructure.com
 # Get a developer key from Canvas and put here the ID and secret of the key
 CANVAS_CLIENT_ID=
 CANVAS_CLIENT_SECRET=
+# Token with admin access for fetching grading standards
+CANVAS_ADMIN_API_TOKEN=
 
 
 # MongoDB connection parameters for saving grading history logs

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,6 +22,7 @@ pipeline {
                 LADOK_API_PFX_PASSPHRASE = credentials('LADOK_API_PFX_PASSPHRASE')
                 CANVAS_CLIENT_ID = credentials('CANVAS_CLIENT_ID_E2E')
                 CANVAS_CLIENT_SECRET = credentials('CANVAS_CLIENT_SECRET_E2E')
+                CANVAS_ADMIN_API_TOKEN = credentials('CANVAS_API_TOKEN_2')
                 MONGODB_CONNECTION_STRING = credentials('MONGODB_CONNECTION_STRING')
 
                 // Since a successful run relies on environment varibles being set,

--- a/lib/canvas.js
+++ b/lib/canvas.js
@@ -2,14 +2,20 @@ const CanvasAPI = require('@kth/canvas-api')
 const log = require('skog')
 const memoizee = require('memoizee')
 
-async function getAccountGradingStandardsWithoutCache (token) {
-  const canvas = CanvasAPI(`${process.env.CANVAS_HOST}/api/v1`, token)
+async function getAccountGradingStandardsWithoutCache () {
+  const canvas = CanvasAPI(
+    `${process.env.CANVAS_HOST}/api/v1`,
+    process.env.CANVAS_ADMIN_API_TOKEN
+  )
 
   return canvas.list(`/accounts/1/grading_standards`).toArray()
 }
 
-async function getCourseGradingStandardsWithoutCache (token, courseId) {
-  const canvas = CanvasAPI(`${process.env.CANVAS_HOST}/api/v1`, token)
+async function getCourseGradingStandardsWithoutCache (courseId) {
+  const canvas = CanvasAPI(
+    `${process.env.CANVAS_HOST}/api/v1`,
+    process.env.CANVAS_ADMIN_API_TOKEN
+  )
 
   return canvas.list(`/courses/${courseId}/grading_standards`).toArray()
 }
@@ -36,8 +42,8 @@ async function getAssignments (token, courseId) {
     .toArray()
 
   const gradingStandards = [
-    ...(await getAccountGradingStandards(token)),
-    ...(await getCourseGradingStandards(token, courseId))
+    ...(await getAccountGradingStandards()),
+    ...(await getCourseGradingStandards(courseId))
   ]
 
   for (const assignment of assignments) {


### PR DESCRIPTION
Noticed that one needs higher permissions to get grading standards (at least for the account ones) than most teachers. To fix this, I re-introduced the admin token as, at least, a short-term solution.