### PR TITLE
New "/app" endpoint and course ID into the cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LMS Export to Ladok 2
+# LMS Transfer to Ladok
 
 ## Copyright © 2019, [KTH](https://github.com/kth).
 

--- a/client/App.js
+++ b/client/App.js
@@ -5,10 +5,8 @@ import { useFetch } from './react-hooks'
 import WizardForm from './WizardForm'
 import WizardConfirm from './WizardConfirm'
 
-function App ({ courseId }) {
-  const { loading, error, data } = useFetch(
-    `api/course-info?course_id=${courseId}`
-  )
+function App () {
+  const { loading, error, data } = useFetch(`api/course-info`)
 
   const [selectedAssignment, setAssignment] = useState(null)
   const [selectedModule, setModule] = useState(null)
@@ -50,13 +48,11 @@ function App ({ courseId }) {
         selectedAssignment={selectedAssignment}
         selectedModule={selectedModule}
         examinationDate={examinationDate}
-        courseId={courseId}
       />
     )
   } else if (currentPage === 3) {
     return (
       <WizardResult
-        courseId={courseId}
         selectedAssignment={selectedAssignment}
         selectedModule={selectedModule}
         examinationDate={examinationDate}

--- a/client/WizardConfirm.js
+++ b/client/WizardConfirm.js
@@ -5,8 +5,7 @@ function WizardConfirm ({
   setCurrentPage,
   selectedAssignment,
   selectedModule,
-  examinationDate,
-  courseId
+  examinationDate
 }) {
   const showTable = selectedAssignment && selectedModule
 
@@ -69,7 +68,6 @@ function WizardConfirm ({
       </div>
       {showTable && (
         <Table
-          course={courseId}
           assignment={selectedAssignment}
           module={selectedModule}
           date={examinationDate}

--- a/client/WizardResult.js
+++ b/client/WizardResult.js
@@ -2,14 +2,12 @@ import React from 'react'
 import { useFetch } from './react-hooks'
 
 function WizardResult ({
-  courseId,
   selectedAssignment,
   selectedModule,
   examinationDate,
   setCurrentPage
 }) {
   const body = {
-    course_id: courseId,
     canvas_assignment: selectedAssignment.id,
     ladok_module: selectedModule.id,
     examination_date: examinationDate

--- a/server/authorization.js
+++ b/server/authorization.js
@@ -15,10 +15,7 @@ async function denyActAs (req, res, next) {
 }
 
 async function authorize (req, res, next) {
-  const accessData = req.accessData || req.signedCookies.access_data
-  const courseId = req.query.course_id || req.body.course_id
-
-  req.accessData = accessData
+  const accessData = req.signedCookies.access_data
 
   if (!accessData) {
     throw new ClientError(
@@ -26,6 +23,7 @@ async function authorize (req, res, next) {
       'No access data found in request or cookie.'
     )
   }
+  const courseId = accessData.courseId
 
   try {
     const allowedInLadok = await isAllowed.isAllowedInLadok(

--- a/server/export-to-ladok.js
+++ b/server/export-to-ladok.js
@@ -29,7 +29,7 @@ async function startPage (req, res) {
 async function showForm (req, res) {
   res.render('form', {
     prefix_path: process.env.PROXY_PATH,
-    token: req.accessData.token,
+    token: req.signedCookies.access_data.token,
     course_id: req.query.course_id,
     layout: false
   })
@@ -54,15 +54,12 @@ async function submitGrades (req, res) {
 
 async function listCourseData (req, res) {
   const courseId = req.signedCookies.access_data.courseId
+  const token = req.signedCookies.access_data.token
 
   log.info(`Fetching data (assignments and modules) of course ${courseId}`)
 
-  const canvasAssignments = await getCanvasAssignments(
-    courseId,
-    req.accessData.token
-  )
-
-  const ladokModules = await getLadokModules(courseId, req.accessData.token)
+  const canvasAssignments = await getCanvasAssignments(courseId, token)
+  const ladokModules = await getLadokModules(courseId, token)
 
   res.send({
     url: `${process.env.CANVAS_HOST}/courses/${courseId}`,
@@ -79,11 +76,14 @@ async function listCourseData (req, res) {
 }
 
 async function listGradesData (req, res) {
+  const courseId = req.signedCookies.access_data.courseId
+  const token = req.signedCookies.access_data.token
+
   const data = await getGrades(
-    req.query.course_id,
+    courseId,
     req.query.assignment_id,
     req.query.module_id,
-    req.accessData.token
+    token
   )
   res.send(data)
 }

--- a/server/export-to-ladok.js
+++ b/server/export-to-ladok.js
@@ -36,11 +36,13 @@ async function showForm (req, res) {
 }
 
 async function submitGrades (req, res) {
+  const courseId = req.signedCookies.access_data.courseId
+
   log.info(
-    `Sending grades of course ${req.body.course_id} - assignment ${req.body.canvas_assignment} to Ladok Module ${req.body.ladok_module}`
+    `Sending grades of course ${courseId} - assignment ${req.body.canvas_assignment} to Ladok Module ${req.body.ladok_module}`
   )
   const result = await sendGradesToLadok(
-    req.body.course_id,
+    courseId,
     req.body.canvas_assignment,
     req.body.ladok_module,
     req.body.examination_date,
@@ -51,7 +53,7 @@ async function submitGrades (req, res) {
 }
 
 async function listCourseData (req, res) {
-  const courseId = req.query.course_id
+  const courseId = req.signedCookies.access_data.courseId
 
   log.info(`Fetching data (assignments and modules) of course ${courseId}`)
 

--- a/server/index.js
+++ b/server/index.js
@@ -59,7 +59,10 @@ if (process.env.NODE_ENV === 'development') {
 router.get('/', rootPage)
 router.post('/export', startPage)
 router.post('/export2', oauth1)
-router.get('/export3', oauth2, authorization.authorize, showForm)
+router.get('/export3', oauth2, function (req, res) {
+  res.redirect('app')
+})
+router.get('/app', authorization.authorize, showForm)
 
 router.get('/_monitor', system.monitor)
 router.get('/_monitor_all', system.monitor)

--- a/server/oauth.js
+++ b/server/oauth.js
@@ -103,12 +103,17 @@ const oauth2 = redirectPath =>
       process.env.PROXY_BASE
     )
 
-    const accessData = await getAccessData(
+    const { token, userId, realUserId } = await getAccessData(
       callbackUrl.toString(),
       req.query.code
     )
 
-    req.accessData = accessData
+    const accessData = {
+      token,
+      userId,
+      realUserId,
+      courseId: req.query.course_id
+    }
     res.cookie('access_data', accessData, { signed: true })
     next()
   }


### PR DESCRIPTION
This PR creates a new endpoint `/app` with the actual application. This means that once you authorize and you reach the app you can "refresh" the page and still work in the same session until the token expires.

The major benefit of this PR is **development speed**. If you (as developer and user) restart the server you can just refresh the browser instead of repeating the whole oauth process.

These are all the endpoints:

- `POST /export`. The start page you land when you click the button in Canvas. The user sees a welcome text
- `POST /export2`. Sends a oauth request to Canvas (i.e. redirects the user to Canvas authentication)
- `GET /export3`. oauth callback. It contains the oauth code in the URL. We get the oauth code and exchange it with the token. We set the cookie with the token and session data (user id, **course id**). Redirects to `/app`
- `GET /app`. Displays the application.

This PR also includes the course ID into the cookie. It is not needed to achieve what it says above but unifies all the "session-related" variables in the same place: the cookies