### PR TITLE
Compare grades in uppercase.

### DIFF
--- a/client/Table.js
+++ b/client/Table.js
@@ -18,7 +18,8 @@ function Table ({ course, assignment, module, date }) {
     const isTransferrable =
       student.ladokGradeData.existsAsDraft &&
       student.canvasGrade &&
-      student.canvasGrade !== student.ladokGradeData.letter
+      student.canvasGrade.toUpperCase() !==
+        student.ladokGradeData.letter.toUpperCase()
     studentRows.push({ student, isTransferrable })
   }
   return (


### PR DESCRIPTION
I noticed that in Canvas, one grade is called "Fx" and in Ladok "FX". To avoid this and future problems I forced uppercase on the strings!