### PR TITLE
Frontend update

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -127,6 +127,15 @@ function App () {
     }
   }
 
+  function startOver () {
+    setSelection({
+      assignment: -1,
+      module: -1,
+      examinationDate: ''
+    })
+    setCurrentPage(1)
+  }
+
   //
   // From here everything is visualization
   //
@@ -192,7 +201,7 @@ function App () {
         origin={origin}
         destination={destination}
         examinationDate={userSelection.examinationDate}
-        onContinue={() => setCurrentPage(1)}
+        onContinue={startOver}
         submissionResponse={submissionResponse}
       />
     )

--- a/client/index.scss
+++ b/client/index.scss
@@ -62,37 +62,6 @@ body {
   place-self: flex-end;
 }
 
-table {
-  display: flex;
-  flex-flow: column;
-  height: 100%;
-  width: 100%;
-}
-
-table thead {
-  /* head takes the height it requires,
-  and it's not scaled when table is resized */
-  flex: 0 0 auto;
-  width: calc(100% - 0.9em);
-}
-
-table tbody {
-  /* body takes all the remaining available space */
-  flex: 1 1 auto;
-  display: block;
-  overflow-y: scroll;
-}
-
-table tbody tr {
-  width: 100%;
-}
-
-table thead,
-table tbody tr {
-  display: table;
-  table-layout: fixed;
-}
-
 #root {
   display: flex;
   flex-flow: column;
@@ -110,20 +79,13 @@ table tbody tr {
 
 .table-container {
   overflow: hidden;
-}
-
-table {
-  margin-bottom: 14px;
-  margin: 0;
-}
-
-caption {
-  padding: 0em;
+  padding-bottom: 10em;
 }
 
 table caption {
-  margin-top: 0px;
-  margin-bottom: 0px;
+  font-size: 1rem;
+  text-align: center;
+  font-weight: 400;
 }
 
 h2 {

--- a/client/index.scss
+++ b/client/index.scss
@@ -9,8 +9,16 @@ body {
   background: $white;
   color: $black;
   height: 100%;
-  margin: 0;
-  padding: $spacing;
+}
+
+@media (min-width: 992px) {
+  body header .container-fluid .container {
+    padding-bottom: 20px;
+  }
+}
+
+.c2l2 {
+  padding: 20px 15px 0;
 }
 
 .start_c2l2_form {
@@ -179,10 +187,14 @@ h2 {
 }
 
 @keyframes fadein {
-    from { opacity: 0; }
-    to   { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
-.fadein{
+.fadein {
   animation: fadein 2s;
 }

--- a/client/index.scss
+++ b/client/index.scss
@@ -88,6 +88,11 @@ table caption {
   font-weight: 400;
 }
 
+table thead tr th,
+table tbody tr td {
+  padding: 4px 8px;
+}
+
 h2 {
   margin: 0px;
 }

--- a/client/index.scss
+++ b/client/index.scss
@@ -38,6 +38,15 @@ body {
   justify-content: space-between;
 }
 
+.button-section-container {
+  width: 100%;
+  padding: 0 45px;
+  padding-top: 0px;
+  padding-bottom: 2em;
+  box-sizing: border-box;
+  background: $white;
+}
+
 .grid-col-1 {
   grid-column: 1;
   place-self: flex-start;
@@ -100,8 +109,6 @@ table tbody tr {
 }
 
 .table-container {
-  height: 10em;
-  flex: 1 1 10em;
   overflow: hidden;
 }
 

--- a/client/index.scss
+++ b/client/index.scss
@@ -40,8 +40,6 @@ body {
 
 .button-section-container {
   width: 100%;
-  padding: 0 45px;
-  padding-top: 0px;
   padding-bottom: 2em;
   box-sizing: border-box;
   background: $white;

--- a/client/table.js
+++ b/client/table.js
@@ -14,10 +14,10 @@ function Table ({ loading, error, data: table }) {
 
   return (
     <div className='table-container'>
-      <table border='1'>
+      <table>
         <caption>
           Can export {sortedList.filter(row => row.transferrable).length}/
-          {sortedList.length} grades:
+          {sortedList.length} grades
         </caption>
         <thead>
           <tr>

--- a/client/wizard-preview.js
+++ b/client/wizard-preview.js
@@ -3,24 +3,26 @@ import Table from './table'
 
 function TableFooter ({ onBack, onSubmit, onCancel }) {
   return (
-    <div className='button-section'>
-      <button
-        type='button'
-        className='btn btn-back btn-secondary grid-col-1'
-        onClick={onBack}
-      >
-        Assignments and Date
-      </button>
-      <button
-        type='button'
-        className='btn btn-secondary grid-col-2'
-        onClick={onCancel}
-      >
-        Cancel
-      </button>
-      <button className='btn btn-primary grid-col-3' onClick={onSubmit}>
-        Transfer to Ladok
-      </button>
+    <div className='fixed-bottom button-section-container'>
+      <div className='button-section'>
+        <button
+          type='button'
+          className='btn btn-back btn-secondary grid-col-1'
+          onClick={onBack}
+        >
+          Assignments and Date
+        </button>
+        <button
+          type='button'
+          className='btn btn-secondary grid-col-2'
+          onClick={onCancel}
+        >
+          Cancel
+        </button>
+        <button className='btn btn-primary grid-col-3' onClick={onSubmit}>
+          Transfer to Ladok
+        </button>
+      </div>
     </div>
   )
 }

--- a/client/wizard-preview.js
+++ b/client/wizard-preview.js
@@ -4,24 +4,26 @@ import Table from './table'
 function TableFooter ({ onBack, onSubmit, onCancel }) {
   return (
     <div className='fixed-bottom button-section-container'>
-      <div className='button-section'>
-        <button
-          type='button'
-          className='btn btn-back btn-secondary grid-col-1'
-          onClick={onBack}
-        >
-          Assignments and Date
-        </button>
-        <button
-          type='button'
-          className='btn btn-secondary grid-col-2'
-          onClick={onCancel}
-        >
-          Cancel
-        </button>
-        <button className='btn btn-primary grid-col-3' onClick={onSubmit}>
-          Transfer to Ladok
-        </button>
+      <div className='container main'>
+        <div className='button-section c2l2'>
+          <button
+            type='button'
+            className='btn btn-back btn-secondary grid-col-1'
+            onClick={onBack}
+          >
+            Assignments and Date
+          </button>
+          <button
+            type='button'
+            className='btn btn-secondary grid-col-2'
+            onClick={onCancel}
+          >
+            Cancel
+          </button>
+          <button className='btn btn-primary grid-col-3' onClick={onSubmit}>
+            Transfer to Ladok
+          </button>
+        </div>
       </div>
     </div>
   )

--- a/client/wizard-result.js
+++ b/client/wizard-result.js
@@ -36,10 +36,10 @@ function WizardResult ({
         </div>
         <div className='button-section'>
           <button
-            className='btn btn-success grid-col-3'
+            className='btn btn-primary grid-col-3'
             onClick={() => onContinue()}
           >
-            Done
+            Start over
           </button>
         </div>
       </>
@@ -64,10 +64,10 @@ function WizardResult ({
       <p>The rest of the grading process is carried out in Ladok</p>
       <div className='button-section'>
         <button
-          className='btn btn-success grid-col-3'
+          className='btn btn-primary grid-col-3'
           onClick={() => onContinue()}
         >
-          Done
+          Transfer more results
         </button>
       </div>
     </>

--- a/server/views/form.handlebars
+++ b/server/views/form.handlebars
@@ -4,11 +4,28 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>KTH Transfer to Ladok</title>
+  <title>Transfer to Ladok | KTH</title>
   <link rel="stylesheet" type="text/css" href="{{prefix_path}}/dist/index.css">
 </head>
 <body>
-  <div id="root"></div>
+  <header role="banner">
+    <div class="container-fluid">
+      <div class="container">
+        <div class="header-container__top">
+          <figure class="block figure defaultTheme mainLogo" data-cid="1.77257" lang="sv-SE">
+            <img class="figure-img img-fluid" src="//kth.se/polopoly_fs/1.77257.1550147376!/KTH_Logotyp_RGB_2013-2.svg" alt="KTH logotype" width="70" height="70">
+          </figure>
+          <h1 class="block siteName">Transfer to Ladok</h1>
+        </div>
+      </div>
+    </div>
+    <div id="gradientBorder"></div>
+  </header>
+  <div class="container main">
+    <div class="c2l2">
+      <div id="root"></div>
+    </div>
+  </div>
   <script src="{{prefix_path}}/dist/index.js"></script>
 </body>
 </html>

--- a/server/views/start.handlebars
+++ b/server/views/start.handlebars
@@ -5,37 +5,54 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Start page</title>
+  <title>Transfer to Ladok | KTH</title>
   <link rel="stylesheet" type="text/css" href="{{prefix_path}}/dist/index.css">
 </head>
 
 <body>
-  <form class="start_c2l2_form" action="{{next}}" method="POST">
-    <div>
-      <h1>KTH Transfer to Ladok</h1>
-      <p>
-        This application has been developed with the intent to enable a secure digital transfer of grades from Canvas Gradebook to
-        Ladok and hopefully also reduce the amount of manual grade administration.</p>
-      <h2>How do I start using the application?</h2>
-      <p>If you have not used this application before, please read the instructions for Canvas Gradebook and this
-        application in <a href="https://kth.instructure.com/courses/1/pages/step-7-information-grades#export-to-ladok" target="_blank" rel="noreferrer noopener">Canvas@KTH</a>
-        carefully. Click the button at the bottom of this page to launch the application.</p>
-      <h2>Important to notice</h2>
-      <ol>
-        <li>The application can transfer letter grades from a column in Canvas Gradebook to draft status for a Ladok
-          module (i.e. not the final grade of the course). In the next step, you will have to select which column in
-          Canvas Gradebook that should be transferred to which Ladok module. Make sure that the column in Canvas
-          Gradebook contains the allowed letter grades for the Ladok module.</li>
-        <li>Grades that have been marked as ready and certified will not be transferred to Ladok, except for F or Fx. Be
-          wary when you want to transfer grades for the second time (e.g. after a re-exam) for a Ladok module.</li>
-        <li>If this course room contains multiple course rounds, only the grades for the students of the main course round can be transferred.</li>
-      </ol>
-      <p><em>Is something not working as expected? <a
-        href="mailto:it-support@kth.se">Contact IT support!</a></em></p>
-      <input type="hidden" name="custom_canvas_course_id" value="{{custom_canvas_course_id}}">
+  <header role="banner">
+    <div class="container-fluid">
+      <div class="container">
+        <div class="header-container__top">
+          <figure class="block figure defaultTheme mainLogo" data-cid="1.77257" lang="sv-SE">
+            <img class="figure-img img-fluid" src="//kth.se/polopoly_fs/1.77257.1550147376!/KTH_Logotyp_RGB_2013-2.svg" alt="KTH logotype" width="70" height="70">
+          </figure>
+          <h1 class="block siteName">Transfer to Ladok</h1>
+        </div>
+      </div>
     </div>
-    <input type="submit" class="btn btn-primary start_C2L2_button" value="Start the application"></input>
-  </form>
+    <div id="gradientBorder"></div>
+  </header>
+  <div class="container main">
+    <div class="c2l2">
+      <form class="start_c2l2_form" action="{{next}}" method="POST">
+        <div>
+          <h1>KTH Transfer to Ladok</h1>
+          <p>
+            This application has been developed with the intent to enable a secure digital transfer of grades from Canvas Gradebook to
+            Ladok and hopefully also reduce the amount of manual grade administration.</p>
+          <h2>How do I start using the application?</h2>
+          <p>If you have not used this application before, please read the instructions for Canvas Gradebook and this
+            application in <a href="https://kth.instructure.com/courses/1/pages/step-7-information-grades#export-to-ladok" target="_blank" rel="noreferrer noopener">Canvas@KTH</a>
+            carefully. Click the button at the bottom of this page to launch the application.</p>
+          <h2>Important to notice</h2>
+          <ol>
+            <li>The application can transfer letter grades from a column in Canvas Gradebook to draft status for a Ladok
+              module (i.e. not the final grade of the course). In the next step, you will have to select which column in
+              Canvas Gradebook that should be transferred to which Ladok module. Make sure that the column in Canvas
+              Gradebook contains the allowed letter grades for the Ladok module.</li>
+            <li>Grades that have been marked as ready and certified will not be transferred to Ladok, except for F or Fx. Be
+              wary when you want to transfer grades for the second time (e.g. after a re-exam) for a Ladok module.</li>
+            <li>If this course room contains multiple course rounds, only the grades for the students of the main course round can be transferred.</li>
+          </ol>
+          <p><em>Is something not working as expected? <a
+            href="mailto:it-support@kth.se">Contact IT support!</a></em></p>
+          <input type="hidden" name="custom_canvas_course_id" value="{{custom_canvas_course_id}}">
+        </div>
+        <input type="submit" class="btn btn-primary start_C2L2_button" value="Start the application"></input>
+      </form>
+    </div>
+  </div>
 </body>
 
 </html>


### PR DESCRIPTION
This PR contains small changes in the frontend part of the app

- Main feature: When user clicks the button to start over again, the form is set to initial state (no assignment, no module, no examination date selected)
- The mentioned button has a new text. Before: "Done". Now: "Transfer more results".
- The application is now wrapped in a "KTH Style container": it has a header with the KTH Logo, the "blue line"; the app is horizontally centered with margins
- Buttons in the table view are now fixed in the bottom.
- Style fix in table: headers and content are no longer misaligned
