### PR TITLE
Use assignment ID instead of array index

### DIFF
--- a/client/app.js
+++ b/client/app.js
@@ -70,8 +70,7 @@ function App () {
   const [submissionResponse, submitGrades] = useSubmitGrades(null)
 
   function previewResult (selection) {
-    console.log(selection)
-    const assignmentId = course.data.assignments[selection.assignment].id
+    const assignmentId = selection.assignment
     const moduleId =
       course.data.modules.length === 0
         ? null
@@ -84,7 +83,9 @@ function App () {
   }
 
   function confirmTransfer () {
-    const selectedAssignment = course.data.assignments[userSelection.assignment]
+    const selectedAssignment = course.data.assignments.find(
+      a => a.id === userSelection.assignment
+    )
     const examinationDate = userSelection.examinationDate
 
     if (course.data.modules.length > 0) {
@@ -163,7 +164,9 @@ function App () {
       />
     )
   } else if (currentPage === 2) {
-    const origin = course.data.assignments[userSelection.assignment].name
+    const origin = course.data.assignments.find(
+      a => a.id === userSelection.assignment
+    ).name
     const destination =
       course.data.modules.length > 0
         ? course.data.modules[userSelection.module].code
@@ -181,7 +184,9 @@ function App () {
       />
     )
   } else if (currentPage === 3) {
-    const origin = course.data.assignments[userSelection.assignment].name
+    const origin = course.data.assignments.find(
+      a => a.id === userSelection.assignment
+    ).name
     const destination =
       course.data.modules.length > 0
         ? course.data.modules[userSelection.module].code

--- a/client/assignment-selector.js
+++ b/client/assignment-selector.js
@@ -4,7 +4,7 @@ export default function AssignmentSelector ({ assignments, onChange, value }) {
   let assignmentWarning = <p />
 
   if (value !== -1) {
-    const selectedAssignment = assignments[value]
+    const selectedAssignment = assignments.find(a => a.id === value, 10)
 
     if (selectedAssignment.type !== 'letter_grade') {
       assignmentWarning = (
@@ -35,13 +35,14 @@ export default function AssignmentSelector ({ assignments, onChange, value }) {
           className='custom-select'
           value={value}
           name='canvas_assignment'
-          onChange={event => onChange(event.target.value)}
+          onChange={event => onChange(parseInt(event.target.value, 10))}
         >
           <option value={-1} disabled hidden>
             Select assignment
           </option>
           {// sort letter grade first, then the rest grouped by grading type
           assignments
+            .slice()
             .sort((a, b) => {
               if (a.type === 'letter_grade') {
                 return -1
@@ -51,8 +52,12 @@ export default function AssignmentSelector ({ assignments, onChange, value }) {
                 return a.name.localeCompare(b.name)
               }
             })
-            .map((assignment, i) => (
-              <option key={i} value={i} disabled={!assignment.published}>
+            .map(assignment => (
+              <option
+                key={assignment.id}
+                value={assignment.id}
+                disabled={!assignment.published}
+              >
                 {assignment.name}: {assignment.type.replace('_', ' ')}
                 {assignment.published ? '' : ' NOT PUBLISHED'}
               </option>

--- a/client/assignment-selector.js
+++ b/client/assignment-selector.js
@@ -4,7 +4,7 @@ export default function AssignmentSelector ({ assignments, onChange, value }) {
   let assignmentWarning = <p />
 
   if (value !== -1) {
-    const selectedAssignment = assignments.find(a => a.id === value, 10)
+    const selectedAssignment = assignments.find(a => a.id === value)
 
     if (selectedAssignment.type !== 'letter_grade') {
       assignmentWarning = (


### PR DESCRIPTION
Fixes a bug where the selected assignment was not predictable (changes without user interaction)

Before, the selected assignment is stored by the position in the list. However that same list is re-ordered in the `<AssignmentSelector>` component and therefore indices do not match.

Now the selected assignment is stored by its Canvas ID