### PR TITLE
Ignore missing students in Canvas

### DIFF
--- a/lib/transfer-examination.js
+++ b/lib/transfer-examination.js
@@ -104,6 +104,14 @@ async function getResults (courseId, assignmentId, token) {
 
     for (const result of results1) {
       const submission = grades.find(s => s.id === result.Student.Uid)
+
+      if (!submission) {
+        log.warn(
+          `Missing student in Canvas ${result.Student.Uid} (${result.Student.Fornamn} ${result.Student.Efternamn} )`
+        )
+        continue
+      }
+
       const ladokGrade =
         submission &&
         submission.grade &&
@@ -119,6 +127,14 @@ async function getResults (courseId, assignmentId, token) {
 
     for (const result of results2) {
       const submission = grades.find(s => s.id === result.Student.Uid)
+
+      if (!submission) {
+        log.warn(
+          `Missing student in Canvas ${result.Student.Uid} (${result.Student.Fornamn} ${result.Student.Efternamn} )`
+        )
+        continue
+      }
+
       const ladokGrade =
         submission &&
         submission.grade &&
@@ -218,6 +234,14 @@ async function transferResults (
 
     for (const result of results1) {
       const submission = grades.find(s => s.id === result.Student.Uid)
+
+      if (!submission) {
+        log.warn(
+          `Missing student in Canvas ${result.Student.Uid} (${result.Student.Fornamn} ${result.Student.Efternamn} )`
+        )
+        continue
+      }
+
       const ladokGrade =
         submission &&
         submission.grade &&
@@ -241,6 +265,14 @@ async function transferResults (
 
     for (const result of results2) {
       const submission = grades.find(s => s.id === result.Student.Uid)
+
+      if (!submission) {
+        log.warn(
+          `Missing student in Canvas ${result.Student.Uid} (${result.Student.Fornamn} ${result.Student.Efternamn} )`
+        )
+        continue
+      }
+
       const ladokGrade =
         submission &&
         submission.grade &&

--- a/lib/transfer-module.js
+++ b/lib/transfer-module.js
@@ -67,6 +67,13 @@ async function getResults (courseId, moduleId, assignmentId, token) {
 
   for (const result of results1) {
     const submission = grades.find(s => s.id === result.Student.Uid)
+
+    if (!submission) {
+      log.info(
+        `Missing student in Canvas ${result.Student.Uid} (${result.Student.Fornamn} ${result.Student.Efternamn} )`
+      )
+      continue
+    }
     const ladokGrade =
       submission &&
       submission.grade &&
@@ -80,6 +87,14 @@ async function getResults (courseId, moduleId, assignmentId, token) {
 
   for (const result of results2) {
     const submission = grades.find(s => s.id === result.Student.Uid)
+
+    if (!submission) {
+      log.info(
+        `Missing student in Canvas ${result.Student.Uid} (${result.Student.Fornamn} ${result.Student.Efternamn} )`
+      )
+      continue
+    }
+
     const ladokGrade =
       submission &&
       submission.grade &&
@@ -162,6 +177,13 @@ async function transferResults (
 
   for (const result of results1) {
     const submission = grades.find(s => s.id === result.Student.Uid)
+    if (!submission) {
+      log.info(
+        `Missing student in Canvas ${result.Student.Uid} (${result.Student.Fornamn} ${result.Student.Efternamn} )`
+      )
+      continue
+    }
+
     const ladokGrade =
       submission &&
       submission.grade &&
@@ -184,6 +206,13 @@ async function transferResults (
 
   for (const result of results2) {
     const submission = grades.find(s => s.id === result.Student.Uid)
+    if (!submission) {
+      log.info(
+        `Missing student in Canvas ${result.Student.Uid} (${result.Student.Fornamn} ${result.Student.Efternamn} )`
+      )
+      continue
+    }
+
     const ladokGrade =
       submission &&
       submission.grade &&


### PR DESCRIPTION
This open fixes a bug that is triggered when a student is not registered in Ladok (and therefore not exist in Canvas) into a course but, for some reason, is shown in Ladok in the "list of people who can get results".

_The solution is to ignore such students. Do not try to put results_