### PR TITLE
Fix error logging

### DIFF
--- a/.env.in
+++ b/.env.in
@@ -1,5 +1,5 @@
 # Url to Ladok API
-LADOK_API_BASEURL=https://api.test.ladok.se
+LADOK_API_BASEURL=https://api.integrationstest.ladok.se
 # Get a PFX certificate from Ladok, put the base64 of that file:
 LADOK_API_PFX_BASE64=
 # If you need a passphrase to unlock the PFX file, set it here

--- a/README.md
+++ b/README.md
@@ -4,11 +4,30 @@
 
 Sends results of an assignment in Canvas LMS as module in Ladok.
 
+# Get started
+
+1. install app
+
+```
+  $ npm i
+```
+
+2. create Ladok certificate
+3. add reporter permissions to Ladok
+4. set up .env
+5. start app
+
+```
+  $ npm run start
+```
+
 # Certificate
+
 This app needs a valid certificate from Ladok since it uploads grades to Ladok. When such a certificate has been downloaded, do the following to generate a base 64 encoded string from the certificate:
 
     openssl pkcs12 -export -out <pfxname>.pfx -inkey <keyname>@KTH.key -in <certname>@KTH.crt
     base64 -i <pfxname>.pfx
+
 Example:
 
     openssl pkcs12 -export -out kth.emilsten.pfx -inkey emilsten@KTH.key -in emilsten@KTH.crt
@@ -17,6 +36,6 @@ Example:
 _Then remove all of the newlines of the newly created base 64 string_ and add this string to the .env file in the `LADOK_API_PFX_BASE64` environment variable.
 
 # Add reporter rights
-After the app is configured to use the Ladok certificate, _the user has to be reporter in all of the subaccounts/schools in Ladok_. This is necessary to let the system user report grades in Ladok.
-To do this, run the script [add-reporter](https://github.com/KTH/lms-scripts/tree/master/add-reporter). 
 
+After the app is configured to use the Ladok certificate, _the user has to be reporter in all of the subaccounts/schools in Ladok_. This is necessary to let the system user report grades in Ladok.
+To do this, run the script [add-reporter](https://github.com/KTH/lms-scripts/tree/master/add-reporter).

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,169 @@
+const log = require("skog");
+/* eslint max-classes-per-file: */
+
+/**
+ * Common ancestor of all operational errors allowing
+ * for more catch all checks.
+ */
+class OperationalError extends Error {
+  constructor(name, statusCode, type, message, details, err) {
+    super(message);
+    this.name = name;
+    this.statusCode = statusCode;
+    this.type = type;
+    this.details = details;
+    this.err = err;
+  }
+}
+
+/**
+ * Error for recoverable programmer errors. This tells the consuming
+ * code that it shouldn't crash the application.
+ */
+class RecoverableError extends Error {
+  constructor({ message = "We encountered an error in our code.", err }) {
+    super(message);
+    this.name = "RecoverableError";
+    this.err = err;
+  }
+}
+
+/**
+ * AuthError should be handled by the frontend
+ * api client.
+ */
+class AuthError extends OperationalError {
+  constructor({ type, message, details, err }) {
+    super("AuthError", 401, type, message, details, err);
+  }
+}
+
+/**
+ * All errors of type EndpointError must be
+ * handled by the frontend code that calls the
+ * actual endpoint.
+ */
+class EndpointError extends OperationalError {
+  // Errors that must be handled by frontend
+  constructor({ type, statusCode, message, details, err }) {
+    super("EndpointError", statusCode, type, message, details, err);
+  }
+}
+
+/**
+ * All errors of type "TheExternalApiError" are known problems that happened when
+ * calling out external api
+ */
+class LadokApiError extends OperationalError {
+  constructor({ type, message, details, err }) {
+    super("LadokApiError", 503, type, message, details, err);
+  }
+}
+
+function isOperationalOrRecoverableError(err) {
+  return err instanceof OperationalError || err instanceof RecoverableError;
+}
+
+// Find a wrapped programmer error
+function getOrigProgrammerError(error) {
+  const { err } = error;
+  let result;
+  if (isOperationalOrRecoverableError(err)) {
+    // .err is an OperationalError so need to check if
+    // that in turn constains a wrapped error
+    result = getOrigProgrammerError(err);
+  } else if (err instanceof Error) {
+    result = err;
+  }
+  return result;
+}
+
+// Find the innermost wrapped operational or recoverable error
+function getMostSignificantError(error) {
+  const { err } = error;
+  if (isOperationalOrRecoverableError(err)) {
+    // If we have wrapped an Operational or Recoverable error
+    // that is the cause and what should be logged
+    return getMostSignificantError(err);
+  }
+
+  return error;
+}
+
+function _formatErrorMsg(name, type, message) {
+  return `(${name}${type ? "/" + type : ""}) ${message}`;
+}
+
+function errorHandler(err, req, res, next) {
+  if (err instanceof AuthError) {
+    // Simple auth errors
+    log.warn(err);
+    // Add error details if provided for debugging
+    if (err.details) log.debug(err.details);
+  } else if (err instanceof EndpointError) {
+    /**
+     * An EndpointError can be caused in four ways:
+     * 1. Thrown by endpoint handler but there was no error in the code
+     * 2. Thrown by endpoint handler due to an error in the code
+     * 3. An [Name]ApiError was caught which wasn't caused by an error in the code
+     * 4. An [Name]ApiError was caught which in turn was caused by an error in the code
+     *
+     * Alternative 2 & 4 will have a wrapped programmer error.
+     */
+    // Since EndpointErrors can wrap other errors we want to make sure we log the most significant error
+    // and the underlying programmer error if one exists
+    const logErr = getMostSignificantError(err);
+    const progErr = getOrigProgrammerError(err);
+
+    if (progErr === undefined) {
+      // If the EndpointError wasn't caused by a programmer error we only need to inform about it.
+      log.info(logErr);
+    } else {
+      // If it was a programmer error it needs to be logged and fixed.
+      log.error(
+        progErr, // this provides a stack trace for the original error that needs to be fixed
+        _formatErrorMsg(logErr.name, logErr.type, logErr.message)
+      );
+    }
+    // Add error details if provided for debugging.
+    if (logErr.details) log.debug(logErr.details);
+  } else if (isOperationalOrRecoverableError(err)) {
+    // These errors should always be wrapped in EndpointError so we log the
+    // outer most error to know what we have missed in our endpoint code
+    log.warn(
+      "This error should be wrapped in an EndpointError for consistency"
+    );
+
+    log.error(
+      getOrigProgrammerError(err), // this provides a stack trace for the original error that needs to be fixed
+      _formatErrorMsg(err.name, err.type, err.message)
+    );
+    // Add error details if provided for debugging
+    if (err.details) log.debug(err.details);
+  } else {
+    // All other passed errors should always be logged as error
+    log.error(err);
+  }
+
+  if (res.headersSent) {
+    return next(err);
+  }
+
+  const error = {
+    type: err.type || "error",
+    message:
+      err.message || "An unknown error occured. Please contact IT-support.",
+    statusCode: err.statusCode,
+  };
+
+  return res.status(err.statusCode !== undefined ? err.statusCode : 500).send({
+    error,
+  });
+}
+
+module.exports = {
+  errorHandler,
+  OperationalError,
+  RecoverableError,
+  LadokApiError,
+};

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -51,7 +51,7 @@ class EndpointError extends OperationalError {
 }
 
 /**
- * All errors of type "TheExternalApiError" are known problems that happened when
+ * All errors of type "LadokApiError" are known problems that happened when
  * calling out external api
  */
 class LadokApiError extends OperationalError {
@@ -161,8 +161,28 @@ function errorHandler(err, req, res, next) {
   });
 }
 
+function ladokGenericErrorHandler(err) {
+  Error.captureStackTrace(err, ladokGenericErrorHandler);
+  switch (err.body && err.body.Felgrupp) {
+    case "commons.fel.grupp.auktorisering":
+      throw new LadokApiError({
+        type: "auth_error",
+        message: `We got auth error when trying to access Ladok (${
+          err.body && err.body.Meddelande
+        })`,
+        err, // Pass the original error
+      });
+    default:
+      throw new LadokApiError({
+        type: "unhandled_error",
+        message: "We encountered an error when trying to access Ladok",
+        err, // Pass the original error
+      });
+  }
+}
 module.exports = {
   errorHandler,
+  ladokGenericErrorHandler,
   OperationalError,
   RecoverableError,
   LadokApiError,

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -70,6 +70,16 @@ class CanvasApiError extends OperationalError {
   }
 }
 
+/**
+ * All errors of type "MongoDbError" are known problems that happened when
+ * calling out external api
+ */
+class MongoDbError extends OperationalError {
+  constructor({ type, message, details, err }) {
+    super("MongoDbError", 503, type, message, details, err);
+  }
+}
+
 function isOperationalOrRecoverableError(err) {
   return err instanceof OperationalError || err instanceof RecoverableError;
 }
@@ -200,12 +210,25 @@ function canvasGenericErrorHandler(err) {
   });
   throw error;
 }
+
+function mongodbGenericErrorHandler(err) {
+  Error.captureStackTrace(err, mongodbGenericErrorHandler);
+  const error = new MongoDbError({
+    type: "unhandled_error",
+    message: "We encountered an error when trying to access MongoDb",
+    err, // Pass the original error
+  });
+  throw error;
+}
+
 module.exports = {
   errorHandler,
   ladokGenericErrorHandler,
   canvasGenericErrorHandler,
+  mongodbGenericErrorHandler,
   OperationalError,
   RecoverableError,
   LadokApiError,
   CanvasApiError,
+  MongoDbError,
 };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -60,6 +60,16 @@ class LadokApiError extends OperationalError {
   }
 }
 
+/**
+ * All errors of type "CanvasApiError" are known problems that happened when
+ * calling out external api
+ */
+class CanvasApiError extends OperationalError {
+  constructor({ type, message, details, err }) {
+    super("CanvasApiError", 503, type, message, details, err);
+  }
+}
+
 function isOperationalOrRecoverableError(err) {
   return err instanceof OperationalError || err instanceof RecoverableError;
 }
@@ -180,10 +190,22 @@ function ladokGenericErrorHandler(err) {
       });
   }
 }
+
+function canvasGenericErrorHandler(err) {
+  Error.captureStackTrace(err, canvasGenericErrorHandler);
+  const error = new CanvasApiError({
+    type: "unhandled_error",
+    message: "We encountered an error when trying to access Canvas",
+    err, // Pass the original error
+  });
+  throw error;
+}
 module.exports = {
   errorHandler,
   ladokGenericErrorHandler,
+  canvasGenericErrorHandler,
   OperationalError,
   RecoverableError,
   LadokApiError,
+  CanvasApiError,
 };

--- a/lib/get-course-structure.js
+++ b/lib/get-course-structure.js
@@ -1,5 +1,9 @@
 const CanvasAPI = require("@kth/canvas-api");
 const { ladokGot } = require("./utils");
+const {
+  ladokGenericErrorHandler,
+} = require("./errors");
+
 /**
  * @typedef {object} Module A module (modul) in Ladok
  *
@@ -24,9 +28,9 @@ const { ladokGot } = require("./utils");
  * @returns {Promise<Module[]>}
  */
 async function getLadokModules(ladokId) {
-  const { body } = await ladokGot.get(
-    `/resultat/kurstillfalle/${ladokId}/moment`
-  );
+  const { body } = await ladokGot
+    .get(`/resultat/kurstillfalle/${ladokId}/moment`)
+    .catch(ladokGenericErrorHandler);
 
   // Information about Aktivitetstillfälle can be found in the array:
   // body.IngaendeMoment[0].Aktivitetstillfallen
@@ -78,9 +82,9 @@ async function getLadokModules(ladokId) {
 async function getLadokExaminationRound(sisId) {
   const ladokId = sisId.split(".")[1];
 
-  const { body: round } = await ladokGot.get(
-    `/resultat/aktivitetstillfalle/${ladokId}`
-  );
+  const { body: round } = await ladokGot
+    .get(`/resultat/aktivitetstillfalle/${ladokId}`)
+    .catch(ladokGenericErrorHandler);
 
   const modules = [];
   for (const koppling of round.Kopplingar) {

--- a/lib/get-course-structure.js
+++ b/lib/get-course-structure.js
@@ -2,6 +2,7 @@ const CanvasAPI = require("@kth/canvas-api");
 const { ladokGot } = require("./utils");
 const {
   ladokGenericErrorHandler,
+  canvasGenericErrorHandler,
 } = require("./errors");
 
 /**
@@ -121,9 +122,11 @@ async function getLadokExaminationRound(sisId) {
 /** @returns {Promise<Assignment[]>} */
 async function getAssignments(courseId, token) {
   const canvas = CanvasAPI(process.env.CANVAS_HOST + "/api/v1", token);
+
   const assignments = await canvas
     .list(`/courses/${courseId}/assignments`)
-    .toArray();
+    .toArray()
+    .catch(canvasGenericErrorHandler);
 
   return assignments.map((assignment) => ({
     id: assignment.id,
@@ -199,8 +202,15 @@ function mergeExaminationRounds(examinationRounds) {
  */
 module.exports = async function getCourseStructure(courseId, token) {
   const canvas = CanvasAPI(process.env.CANVAS_HOST + "/api/v1", token);
-  const { body: course } = await canvas.get(`/courses/${courseId}`);
-  const sections = await canvas.list(`/courses/${courseId}/sections`).toArray();
+  const { body: course } = await canvas
+    .get(`/courses/${courseId}`)
+    .catch(canvasGenericErrorHandler);
+
+  const sections = await canvas
+    .list(`/courses/${courseId}/sections`)
+    .toArray()
+    .catch(canvasGenericErrorHandler);
+
   const assignments = await getAssignments(courseId, token);
 
   const allModules = [];

--- a/lib/is-allowed.js
+++ b/lib/is-allowed.js
@@ -6,6 +6,7 @@ const CanvasAPI = require("@kth/canvas-api");
 const {
   ladokGenericErrorHandler,
   canvasGenericErrorHandler,
+  CanvasApiError,
 } = require("./errors");
 
 const ladokGot = got.extend({
@@ -74,22 +75,33 @@ async function isAllowedInCanvas(token, courseId) {
   return true;
 }
 
+function canvasLoginErrorHandler(err) {
+  Error.captureStackTrace(err, canvasLoginErrorHandler);
+  const error = new CanvasApiError({
+    type: "login_error",
+    message: "Cannot get login ID from this user",
+  });
+  throw error;
+}
+
 async function isAllowedInLadok(token, courseId) {
   const canvas = CanvasAPI(`${process.env.CANVAS_HOST}/api/v1`, token);
   log.info("Checking if user is allowed in Ladok");
 
   let loginId;
   try {
-    const { body: user } = await canvas.get(`/courses/${courseId}/users/self`);
+    const { body: user } = await canvas
+      .get(`/courses/${courseId}/users/self`)
+      .catch(canvasLoginErrorHandler);
+
     log.info("Login ID for currentUser:", user.login_id);
     loginId = user.login_id;
   } catch (err) {
-    log.error("Cannot get login ID from this user");
-
+    // TODO: Is this an error that should trigger alert or just a warning?
+    log.error(err);
     return false;
   }
 
-  const reporters = await listReporters();
   const reporters = await listReporters(); // Error handler in called function
   const ladokReporter = reporters[loginId];
   if (ladokReporter) {

--- a/lib/is-allowed.js
+++ b/lib/is-allowed.js
@@ -3,7 +3,9 @@ const got = require("got");
 const memoizee = require("memoizee");
 
 const CanvasAPI = require("@kth/canvas-api");
-const { LadokApiError } = require("./errors");
+const {
+  ladokGenericErrorHandler,
+} = require("./errors");
 
 const ladokGot = got.extend({
   baseUrl: process.env.LADOK_API_BASEURL,
@@ -15,22 +17,12 @@ const ladokGot = got.extend({
   },
 });
 
-function ladokErrorHandler(err) {
-  Error.captureStackTrace(err, ladokErrorHandler);
-  const error = new LadokApiError({
-    type: "unhandled_error",
-    message: "We encountered an error when trying to access Ladok",
-    err, // Pass the original error
-  });
-  throw error;
-}
-
 async function listReportersRaw() {
   const { body } = await ladokGot
     .get(
       `/kataloginformation/behorighetsprofil/${process.env.LADOK_REPORTER_PROFILE_UID}/koppladeanvandare`
     )
-    .catch(ladokErrorHandler);
+    .catch(ladokGenericErrorHandler);
 
   const users = {};
   body.Anvandare.forEach((user) => {
@@ -111,13 +103,15 @@ async function isAllowedInLadok(token, courseId) {
 async function isAllowed(token, courseId) {
   try {
     const results = await Promise.all([
-      isAllowedInCanvas(token, courseId),
-      isAllowedInLadok(token, courseId),
+      isAllowedInCanvas(token, courseId), // Error handler in called function
+      isAllowedInLadok(token, courseId), // Error handler in called function
     ]);
 
     return results[0] && results[1];
   } catch (e) {
-    log.error(e);
+    // TODO: Should this really be logged as error?
+    Error.captureStackTrace(e);
+    log.error(e.err || e, e.message);
     return false;
   }
 }

--- a/lib/is-allowed.js
+++ b/lib/is-allowed.js
@@ -97,8 +97,7 @@ async function isAllowedInLadok(token, courseId) {
     log.info("Login ID for currentUser:", user.login_id);
     loginId = user.login_id;
   } catch (err) {
-    // TODO: Is this an error that should trigger alert or just a warning?
-    log.error(err);
+    log.warn(err);
     return false;
   }
 
@@ -124,9 +123,8 @@ async function isAllowed(token, courseId) {
 
     return results[0] && results[1];
   } catch (e) {
-    // TODO: Should this really be logged as error?
     Error.captureStackTrace(e);
-    log.error(e.err || e, e.message);
+    log.warn(e.err || e, e.message);
     return false;
   }
 }

--- a/lib/is-allowed.js
+++ b/lib/is-allowed.js
@@ -5,6 +5,7 @@ const memoizee = require("memoizee");
 const CanvasAPI = require("@kth/canvas-api");
 const {
   ladokGenericErrorHandler,
+  canvasGenericErrorHandler,
 } = require("./errors");
 
 const ladokGot = got.extend({
@@ -51,7 +52,8 @@ async function isAllowedInCanvas(token, courseId) {
 
   const enrollments = await canvas
     .list(`/courses/${courseId}/enrollments`, { user_id: "self" })
-    .toArray();
+    .toArray()
+    .catch(canvasGenericErrorHandler);
 
   const allowedRoles = enrollments
     .map((enrollment) => parseInt(enrollment.role_id, 10))
@@ -88,6 +90,7 @@ async function isAllowedInLadok(token, courseId) {
   }
 
   const reporters = await listReporters();
+  const reporters = await listReporters(); // Error handler in called function
   const ladokReporter = reporters[loginId];
   if (ladokReporter) {
     log.info("The user is one of the result reporters in Ladok", ladokReporter);

--- a/lib/is-allowed.js
+++ b/lib/is-allowed.js
@@ -3,6 +3,7 @@ const got = require("got");
 const memoizee = require("memoizee");
 
 const CanvasAPI = require("@kth/canvas-api");
+const { LadokApiError } = require("./errors");
 
 const ladokGot = got.extend({
   baseUrl: process.env.LADOK_API_BASEURL,
@@ -14,10 +15,22 @@ const ladokGot = got.extend({
   },
 });
 
+function ladokErrorHandler(err) {
+  Error.captureStackTrace(err, ladokErrorHandler);
+  const error = new LadokApiError({
+    type: "unhandled_error",
+    message: "We encountered an error when trying to access Ladok",
+    err, // Pass the original error
+  });
+  throw error;
+}
+
 async function listReportersRaw() {
-  const { body } = await ladokGot.get(
-    `/kataloginformation/behorighetsprofil/${process.env.LADOK_REPORTER_PROFILE_UID}/koppladeanvandare`
-  );
+  const { body } = await ladokGot
+    .get(
+      `/kataloginformation/behorighetsprofil/${process.env.LADOK_REPORTER_PROFILE_UID}/koppladeanvandare`
+    )
+    .catch(ladokErrorHandler);
 
   const users = {};
   body.Anvandare.forEach((user) => {

--- a/lib/mongo.js
+++ b/lib/mongo.js
@@ -1,4 +1,5 @@
 const { MongoClient } = require("mongodb");
+const { mongodbGenericErrorHandler } = require("./errors");
 
 let db;
 
@@ -17,7 +18,7 @@ async function init() {
     ssl: true,
   });
 
-  await client.connect();
+  await client.connect().catch(mongodbGenericErrorHandler);
   db = client.db(process.env.MONGODB_DATABASE_NAME);
 }
 

--- a/lib/transfer-examination.js
+++ b/lib/transfer-examination.js
@@ -5,6 +5,7 @@ const { ladokGot, ladokSearch, getLadokGrade } = require("./utils");
 const mongo = require("./mongo");
 const {
   ladokGenericErrorHandler,
+  canvasGenericErrorHandler,
 } = require("./errors");
 
 function getLadokId(section) {
@@ -74,7 +75,12 @@ async function getResults(courseId, assignmentId, token) {
   );
 
   const canvas = CanvasAPI(`${process.env.CANVAS_HOST}/api/v1`, token);
-  const sections = await canvas.list(`/courses/${courseId}/sections`).toArray();
+
+  const sections = await canvas
+    .list(`/courses/${courseId}/sections`)
+    .toArray()
+    .catch(canvasGenericErrorHandler);
+
   const examinationRounds = new Set(
     sections.map(getLadokId).filter((id) => id)
   );
@@ -87,7 +93,8 @@ async function getResults(courseId, assignmentId, token) {
     .list(`/courses/${courseId}/assignments/${assignmentId}/submissions`, {
       include: ["user"],
     })
-    .toArray();
+    .toArray()
+    .catch(canvasGenericErrorHandler);
 
   log.info(
     `Course ${courseId} - assignment ${assignmentId} has ${submissions.length} submissions`
@@ -184,18 +191,26 @@ async function transferResults(courseId, assignmentId, examinationDate, token) {
   );
   const canvas = CanvasAPI(`${process.env.CANVAS_HOST}/api/v1`, token);
 
-  const { body: user } = await canvas.get("/users/self");
+  const { body: user } = await canvas
+    .get("/users/self")
+    .catch(canvasGenericErrorHandler);
+
   const submissions = await canvas
     .list(`/courses/${courseId}/assignments/${assignmentId}/submissions`, {
       include: ["user"],
     })
-    .toArray();
+    .toArray()
+    .catch(canvasGenericErrorHandler);
 
   log.info(
     `Course ${courseId} - assignment ${assignmentId} has ${submissions.length} submissions`
   );
 
-  const sections = await canvas.list(`/courses/${courseId}/sections`).toArray();
+  const sections = await canvas
+    .list(`/courses/${courseId}/sections`)
+    .toArray()
+    .catch(canvasGenericErrorHandler);
+
   const examinationRounds = new Set(
     sections.map(getLadokId).filter((id) => id)
   );

--- a/lib/transfer-examination.js
+++ b/lib/transfer-examination.js
@@ -3,6 +3,9 @@ const CanvasAPI = require("@kth/canvas-api");
 const log = require("skog");
 const { ladokGot, ladokSearch, getLadokGrade } = require("./utils");
 const mongo = require("./mongo");
+const {
+  ladokGenericErrorHandler,
+} = require("./errors");
 
 function getLadokId(section) {
   // eslint-disable-next-line camelcase
@@ -20,9 +23,11 @@ async function getCourseRounds(examinationRoundId) {
 
   do {
     currentPage++;
-    const { body } = await ladokGot.get(
-      `/resultat/aktivitetstillfallesmojlighet/filtrera?aktivitetstillfalleUID=${examinationRoundId}&page=${currentPage}&limit=400`
-    );
+    const { body } = await ladokGot
+      .get(
+        `/resultat/aktivitetstillfallesmojlighet/filtrera?aktivitetstillfalleUID=${examinationRoundId}&page=${currentPage}&limit=400`
+      )
+      .catch(ladokGenericErrorHandler);
 
     amount = body.TotaltAntalPoster;
 
@@ -311,15 +316,19 @@ async function transferResults(courseId, assignmentId, examinationDate, token) {
   };
   mongo.write(dataLog);
 
-  const r1 = await ladokGot.post("/resultat/studieresultat/skapa", {
-    body: transferObject1,
-  });
+  const r1 = await ladokGot
+    .post("/resultat/studieresultat/skapa", {
+      body: transferObject1,
+    })
+    .catch(ladokGenericErrorHandler);
 
   log.info(`Created ${r1.body.Resultat.length} results in Ladok`);
 
-  const r2 = await ladokGot.put("/resultat/studieresultat/uppdatera", {
-    body: transferObject2,
-  });
+  const r2 = await ladokGot
+    .put("/resultat/studieresultat/uppdatera", {
+      body: transferObject2,
+    })
+    .catch(ladokGenericErrorHandler);
 
   log.info(`Updated ${r2.body.Resultat.length} results in Ladok`);
 

--- a/lib/transfer-module.js
+++ b/lib/transfer-module.js
@@ -9,6 +9,9 @@ const CanvasAPI = require("@kth/canvas-api");
 const log = require("skog");
 const { ladokGot, ladokSearch, getLadokGrade } = require("./utils");
 const mongo = require("./mongo");
+const {
+  ladokGenericErrorHandler,
+} = require("./errors");
 
 async function searchLadokResults(moduleId, courseRounds, mode) {
   return ladokSearch(
@@ -257,13 +260,17 @@ async function transferResults(
   };
   mongo.write(dataLog);
 
-  const r1 = await ladokGot.post("/resultat/studieresultat/skapa", {
-    body: transferObject1,
-  });
+  const r1 = await ladokGot
+    .post("/resultat/studieresultat/skapa", {
+      body: transferObject1,
+    })
+    .catch(ladokGenericErrorHandler);
 
-  const r2 = await ladokGot.put("/resultat/studieresultat/uppdatera", {
-    body: transferObject2,
-  });
+  const r2 = await ladokGot
+    .put("/resultat/studieresultat/uppdatera", {
+      body: transferObject2,
+    })
+    .catch(ladokGenericErrorHandler);
 
   return [...r1.body.Resultat, ...r2.body.Resultat];
 }

--- a/lib/transfer-module.js
+++ b/lib/transfer-module.js
@@ -11,6 +11,7 @@ const { ladokGot, ladokSearch, getLadokGrade } = require("./utils");
 const mongo = require("./mongo");
 const {
   ladokGenericErrorHandler,
+  canvasGenericErrorHandler,
 } = require("./errors");
 
 async function searchLadokResults(moduleId, courseRounds, mode) {
@@ -38,7 +39,11 @@ async function getResults(courseId, moduleId, assignmentId, token) {
   );
 
   const canvas = CanvasAPI(`${process.env.CANVAS_HOST}/api/v1`, token);
-  const sections = await canvas.list(`/courses/${courseId}/sections`).toArray();
+
+  const sections = await canvas
+    .list(`/courses/${courseId}/sections`)
+    .toArray()
+    .catch(canvasGenericErrorHandler);
 
   log.info(`Course ${courseId} has ${sections.length} sections`);
 
@@ -50,7 +55,8 @@ async function getResults(courseId, moduleId, assignmentId, token) {
     .list(`/courses/${courseId}/assignments/${assignmentId}/submissions`, {
       include: ["user"],
     })
-    .toArray();
+    .toArray()
+    .catch(canvasGenericErrorHandler);
 
   log.info(
     `Course ${courseId} - assignment ${assignmentId} has ${submissions.length} submissions`
@@ -144,13 +150,22 @@ async function transferResults(
   );
 
   const canvas = CanvasAPI(`${process.env.CANVAS_HOST}/api/v1`, token);
+
   const submissions = await canvas
     .list(`/courses/${courseId}/assignments/${assignmentId}/submissions`, {
       include: ["user"],
     })
-    .toArray();
-  const { body: user } = await canvas.get("/users/self");
-  const sections = await canvas.list(`/courses/${courseId}/sections`).toArray();
+    .toArray()
+    .catch(canvasGenericErrorHandler);
+
+  const { body: user } = await canvas
+    .get("/users/self")
+    .catch(canvasGenericErrorHandler);
+
+  const sections = await canvas
+    .list(`/courses/${courseId}/sections`)
+    .toArray()
+    .catch(canvasGenericErrorHandler);
 
   log.info(`Course ${courseId} has ${sections.length} sections`);
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 const memoizee = require("memoizee");
 const got = require("got");
+const { ladokGenericErrorHandler } = require("./errors");
 
 const ladokGot = got.extend({
   baseUrl: process.env.LADOK_API_BASEURL,
@@ -74,7 +75,7 @@ async function ladokSearch(endpoint, criteria) {
         Page: currentPage,
         Limit: pageSize,
       },
-    });
+    }).catch(ladokGenericErrorHandler);
 
     result = [...result, ...body.Resultat];
     totalPages = Math.ceil(body.TotaltAntalPoster / pageSize);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,7 +23,8 @@ const ladokGot2 = got.extend({
 async function gradingScalesRaw() {
   return ladokGot
     .get("/resultat/grunddata/betygsskala")
-    .then((r) => r.body.Betygsskala);
+    .then((r) => r.body.Betygsskala)
+    .catch(ladokGenericErrorHandler);
 }
 
 const getGradingScales = memoizee(gradingScalesRaw, { maxAge: 3600 * 1000 });

--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,7 @@ const { startPage, showForm } = require("./export-to-ladok");
 const getCourseStructure = require("../lib/get-course-structure");
 const transferExamination = require("../lib/transfer-examination");
 const transferModule = require("../lib/transfer-module");
+const { errorHandler } = require("../lib/errors");
 
 const server = express();
 server.set("views", path.join(__dirname, "/views"));
@@ -175,12 +176,5 @@ server.use((err, req, res, next) => {
  * In that case, the app response is a 500.
  */
 // eslint-disable-next-line no-unused-vars
-server.use((err, req, res, next) => {
-  log.error({
-    req,
-    res,
-    err,
-  });
-  res.status(500).send("Unexpected error. Status 500");
-});
+server.use(errorHandler);
 module.exports = server;

--- a/server/system.js
+++ b/server/system.js
@@ -1,11 +1,12 @@
 const packageFile = require("../package.json");
 const version = require("../config/version");
 const { ladokGot2 } = require("../lib/utils");
+const { ladokGenericErrorHandler } = require("../lib/errors");
 
 async function about(req, res) {
-  const { body } = await ladokGot2.get(
-    "/kataloginformation/anvandare/autentiserad"
-  );
+  const { body } = await ladokGot2
+    .get("/kataloginformation/anvandare/autentiserad")
+    .catch(ladokGenericErrorHandler);
   const { Anvandarnamn } = JSON.parse(body);
 
   res.setHeader("Content-Type", "text/plain");


### PR DESCRIPTION
This PR adds a proper stack trace to errors triggered by call to Ladok. Implemented in a single place for review. Let me know if you want me to go ahead and add it to ALL external API-calls (canvas and ladok).

Sample output:
```
13:51:17.719Z ERROR lms-export-to-ladok-2: (LadokApiError/unhandled_error) We encountered an error when trying to access Ladok (req_id=ckvs5izs00003l9ji7gu516ko, app=lms-export-to-ladok-2)
    HTTPError: Response code 403 (Forbidden)
        at processTicksAndRejections (internal/process/task_queues.js:97:5)
        at async listReportersRaw (/Users/jhsware/node/KTH/lms-export-to-ladok-2/lib/is-allowed.js:29:20)
        at async isAllowedInLadok (/Users/jhsware/node/KTH/lms-export-to-ladok-2/lib/is-allowed.js:98:21)
        at async oauth2Middleware (/Users/jhsware/node/KTH/lms-export-to-ladok-2/server/oauth.js:180:28)
```