### PR TITLE
Fix expose errors to front

### DIFF
--- a/client/wizard-result.js
+++ b/client/wizard-result.js
@@ -11,10 +11,23 @@ function WizardResult({
   if (submissionResponse.loading)
     return <Loader reason="Transfering results to ladok ..." />;
   if (submissionResponse.error) {
+    let errTitle;
+    let errDescription;
+    if (
+      ["ladok_rule_error", "ladok_auth_error"].indexOf(
+        submissionResponse.error.type
+      ) >= 0
+    ) {
+      errTitle = submissionResponse.error.message;
+      errDescription = undefined;
+    } else {
+      errTitle = "An error has occurred during the transfer.";
+      errDescription = submissionResponse.error.message;
+    }
     return (
       <>
         <div className="alert alert-danger" aria-live="polite" role="alert">
-          <h2>An error has occurred during the transfer.</h2>
+          <h2>{errTitle}</h2>
           <p>
             No grades were transferred.
             <br />
@@ -24,9 +37,11 @@ function WizardResult({
             <br />
             Examination date: <strong>{examinationDate}</strong>
           </p>
-          <p>
-            <strong>{submissionResponse.error.message}</strong>
-          </p>
+          {errDescription && (
+            <p>
+              <strong>{errDescription}</strong>
+            </p>
+          )}
           <p>
             <em>
               If you need help,{" "}

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -176,14 +176,22 @@ function errorHandler(err, req, res, next) {
     statusCode: err.statusCode,
   };
 
+  // NOTE: react-hooks appears to add the response object body to a prop error so
+  // we need to flatten the error object one level to avoid nested error.error
   return res.status(err.statusCode !== undefined ? err.statusCode : 500).send({
-    error,
+    ...error,
   });
 }
 
 function ladokGenericErrorHandler(err) {
   Error.captureStackTrace(err, ladokGenericErrorHandler);
   switch (err.body && err.body.Felgrupp) {
+    case "commons.fel.grupp.domanregel":
+      throw new LadokApiError({
+        type: "rule_error",
+        message: err.body.Meddelande,
+        err, // Pass the original error
+      });
     case "commons.fel.grupp.auktorisering":
       throw new LadokApiError({
         type: "auth_error",
@@ -226,6 +234,7 @@ module.exports = {
   ladokGenericErrorHandler,
   canvasGenericErrorHandler,
   mongodbGenericErrorHandler,
+  EndpointError,
   OperationalError,
   RecoverableError,
   LadokApiError,

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -186,7 +186,8 @@ function errorHandler(err, req, res, next) {
 function ladokGenericErrorHandler(err) {
   Error.captureStackTrace(err, ladokGenericErrorHandler);
   switch (err.body && err.body.Felgrupp) {
-    case "commons.fel.grupp.domanregel":
+    case "commons.fel.grupp.felaktig_status": // status på data
+    case "commons.fel.grupp.domanregel": // användarrättigheter
       throw new LadokApiError({
         type: "rule_error",
         message: err.body.Meddelande,

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -151,7 +151,7 @@ function errorHandler(err, req, res, next) {
     // These errors should always be wrapped in EndpointError so we log the
     // outer most error to know what we have missed in our endpoint code
     log.warn(
-      "This error should be wrapped in an EndpointError for consistency"
+      "The following error should be wrapped in an EndpointError for consistency:"
     );
 
     log.error(

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "lms-export-to-ladok-2",
   "version": "1.0.0",
+  "engines": {
+    "node": ">=14"
+  },
   "description": "Send results of an assignment in Canvas LMS as module in Ladok",
   "main": "app.js",
   "scripts": {
@@ -11,7 +14,7 @@
     "format": "prettier --write .",
     "start": "node .",
     "build": "NODE_ENV=production webpack",
-    "debug": "NODE_ENV=development node --nolazy --inspect-brk=9229 app.js | bunyan -o short",
+    "debug": "NODE_ENV=development node --nolazy app.js | bunyan -o short",
     "dev": "NODE_ENV=development node . | bunyan -o short"
   },
   "repository": {

--- a/server/index.js
+++ b/server/index.js
@@ -79,11 +79,11 @@ apiRouter.get("/course-info", async (req, res) => {
     const response = await getCourseStructure(courseId, token);
     res.send(response);
   } catch (err) {
-    const msg = `Problems getting course info`;
-    log.error(msg, err);
-    res.status(500).send({
-      code: "ladok_fetch_course_info_error",
-      message: `${msg} - ${err.message}`,
+    throw new EndpointError({
+      type: "ladok_fetch_course_info_error",
+      statusCode: 500,
+      message: `Problems fetching results - ${err.message}`,
+      err,
     });
   }
 });
@@ -112,11 +112,11 @@ apiRouter.get("/table", async (req, res) => {
       res.send(result);
     }
   } catch (err) {
-    const msg = `Problems fetching results`;
-    log.error(msg, err);
-    res.status(500).send({
-      code: "ladok_fetch_results_error",
-      message: `${msg} - ${err.message}`,
+    throw new EndpointError({
+      type: "ladok_fetch_results_error",
+      statusCode: 500,
+      message: `Problems fetching results - ${err.message}`,
+      err,
     });
   }
 });


### PR DESCRIPTION
Improved error exposure to frontend. Might have been a regression bug but this was also an improvement:
<img width="749" alt="Skärmavbild 2021-12-08 kl  15 07 55" src="https://user-images.githubusercontent.com/3896884/145222667-ddab7416-bf0b-4c51-809b-6cecbea10aa1.png">

<img width="1041" alt="Skärmavbild 2021-12-09 kl  11 20 39" src="https://user-images.githubusercontent.com/3896884/145378458-f08b24a9-ede0-47bf-b968-ee176786a5f5.png">

