### PR TITLE
Allow partial transfers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 0. Compile the frontend code
-FROM kthse/kth-nodejs:12.0.0
+FROM node:14-alpine
 WORKDIR /tmp/lms-export-to-ladok-2/
 RUN apk update && \
   apk add --no-cache --virtual .gyp \
@@ -13,7 +13,7 @@ COPY . .
 RUN npm run build
 
 # Stage 1. Build the actual image
-FROM kthse/kth-nodejs:12.0.0
+FROM node:14-alpine
 WORKDIR /usr/src/app
 RUN apk update && \
   apk add --no-cache --virtual .gyp \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 0. Compile the frontend code
-FROM node:14-alpine
+FROM kthse/kth-nodejs:12.0.0
 WORKDIR /tmp/lms-export-to-ladok-2/
 RUN apk update && \
   apk add --no-cache --virtual .gyp \
@@ -13,7 +13,7 @@ COPY . .
 RUN npm run build
 
 # Stage 1. Build the actual image
-FROM node:14-alpine
+FROM kthse/kth-nodejs:12.0.0
 WORKDIR /usr/src/app
 RUN apk update && \
   apk add --no-cache --virtual .gyp \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # Stage 0. Compile the frontend code
-FROM kthse/kth-nodejs:12.0.0
+FROM kthse/kth-nodejs:14.0.0
 WORKDIR /tmp/lms-export-to-ladok-2/
 RUN apk update && \
   apk add --no-cache --virtual .gyp \
-  python \
+  python3 \
   make \
   g++
 # Copying only package.json to avoid reinstalling dependencies if only code has changed
@@ -13,11 +13,11 @@ COPY . .
 RUN npm run build
 
 # Stage 1. Build the actual image
-FROM kthse/kth-nodejs:12.0.0
+FROM kthse/kth-nodejs:14.0.0
 WORKDIR /usr/src/app
 RUN apk update && \
   apk add --no-cache --virtual .gyp \
-  python \
+  python3 \
   make
 COPY . .
 COPY --from=0 /tmp/lms-export-to-ladok-2/dist ./dist

--- a/client/wizard-result.js
+++ b/client/wizard-result.js
@@ -59,16 +59,30 @@ function WizardResult({
             Start over
           </button>
         </div>
-      </>
+      </> /* fix syntax highlight */
     );
   }
+  const submissionIssues = submissionResponse.data.filter(
+    (t) => t.type === "transfer_error"
+  );
+  const nrofSuccess = submissionResponse.data.filter(
+    (t) => t.type !== "transfer_error"
+  ).length;
+  const hasIssues = submissionIssues.length !== nrofSuccess;
 
   return (
     <>
-      <div className="alert alert-success" role="alert">
-        <h2>The transfer was successful.</h2>
+      <div
+        className={`alert ${hasIssues ? "alert-info" : "alert-success"}`}
+        role="alert"
+      >
+        {hasIssues ? (
+          <h2>The transfer had issues, some grades were not transferred.</h2>
+        ) : (
+          <h2>The transfer was successful.</h2>
+        )}
         <p>
-          {submissionResponse.data.length} results have been transferred.
+          {nrofSuccess} results have been transferred.
           <br />
           From: <strong>{origin}</strong>
           <br />
@@ -77,6 +91,29 @@ function WizardResult({
           Examination date: <strong>{examinationDate}</strong>
         </p>
       </div>
+      {submissionIssues.length > 0 && (
+        <div className="table-container">
+          <table>
+            <caption>We could not transfer the following grades:</caption>
+            <thead>
+              <tr>
+                <th>Student</th>
+                <th>PersonNr</th>
+                <th>Reason</th>
+              </tr>
+            </thead>
+            <tbody>
+              {submissionIssues.map((item) => (
+                <tr key={item.studentLadokId}>
+                  <td>{item.studentName}</td>
+                  <td>{item.studentPersonNr}</td>
+                  <td>{item.message}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
       <h2 className="success-h2">Continue the grading process in Ladok</h2>
       <p>The rest of the grading process is carried out in Ladok</p>
       <div className="button-section">

--- a/lib/transfer-module.js
+++ b/lib/transfer-module.js
@@ -12,6 +12,7 @@ const mongo = require("./mongo");
 const {
   ladokGenericErrorHandler,
   canvasGenericErrorHandler,
+  LadokApiError,
 } = require("./errors");
 
 async function searchLadokResults(moduleId, courseRounds, mode) {
@@ -287,6 +288,7 @@ async function transferResults(
   log.info(`Found ${resultsUpdate.length} results in Ladok for Update`);
 
   // 2. Process results and send create/update instructions to LADOK
+  // Data skall ej lagras
   const resultsForFunctionReturnValue = [];
 
   const commonParams = {
@@ -316,14 +318,32 @@ async function transferResults(
     }
     resultsForLogCreated.push(resultObj);
 
-    const res = await ladokGot
-      .post("/resultat/studieresultat/skapa", {
-        body: {
-          LarosateID: process.env.LADOK_KTH_LAROSATE_ID,
-          Resultat: [resultObj],
-        },
-      })
-      .catch(ladokGenericErrorHandler);
+    let res;
+    try {
+      res = await ladokGot
+        .post("/resultat/studieresultat/skapa", {
+          body: {
+            LarosateID: process.env.LADOK_KTH_LAROSATE_ID,
+            Resultat: [resultObj],
+          },
+        })
+        .catch(ladokGenericErrorHandler);
+    } catch (err) {
+      if (err instanceof LadokApiError && err.type === "rule_error") {
+        // This error should not prevent us from continuing
+        resultsForFunctionReturnValue.push({
+          type: "transfer_error",
+          studentName: `${result.Student.Fornamn} ${result.Student.Efternamn}`,
+          studentLadokId: result.Student.Uid,
+          studentPersonNr: result.Student.Personnummer, // Data skall ej lagras
+          message: err.message,
+        });
+        continue;
+      }
+      // Throw all other errors
+      throw err;
+    }
+    // TODO: Handle errors differently
     resultsForFunctionReturnValue.push(res.body.Resultat);
   }
 
@@ -348,13 +368,31 @@ async function transferResults(
     }
     resultsForLogUpdated.push(resultObj);
 
-    const res = await ladokGot
-      .put("/resultat/studieresultat/uppdatera", {
-        body: {
-          Resultat: [resultObj],
-        },
-      })
-      .catch(ladokGenericErrorHandler);
+    let res;
+    try {
+      res = await ladokGot
+        .put("/resultat/studieresultat/uppdatera", {
+          body: {
+            Resultat: [resultObj],
+          },
+        })
+        .catch(ladokGenericErrorHandler);
+    } catch (err) {
+      if (err instanceof LadokApiError && err.type === "rule_error") {
+        // This error should not prevent us from continuing
+        resultsForFunctionReturnValue.push({
+          type: "transfer_error",
+          studentName: `${result.Student.Fornamn} ${result.Student.Efternamn}`,
+          studentLadokId: result.Student.Uid,
+          studentPersonNr: result.Student.Personnummer, // Data skall ej lagras
+          message: err.message,
+        });
+        continue;
+      }
+      // Throw all other errors
+      throw err;
+    }
+    // TODO: Handle errors differently
     resultsForFunctionReturnValue.push(res.body.Resultat);
   }
 

--- a/lib/transfer-module.js
+++ b/lib/transfer-module.js
@@ -131,6 +131,93 @@ async function getResults(courseId, moduleId, assignmentId, token) {
   return grades;
 }
 
+class ResultObjectError extends Error {
+  constructor({ type, message }) {
+    super(message);
+    this.type = type;
+  }
+}
+
+/**
+ * Create a result object that can be sent to LADOK.
+ *
+ * @param {string} param0.submissionType [create|update]
+ * @param {array} param0.grades
+ * @param {object} param0.result
+ * @param {string} param0.moduleId
+ * @param {string} param0.examinationDate
+ * @returns LadokResultObject
+ */
+async function createLadokResultObject({
+  actionType,
+  grades,
+  result,
+  moduleId,
+  examinationDate,
+}) {
+  const submission = grades.find((s) => s.id === result.Student.Uid);
+  if (!submission) {
+    // This should be logged with log.info
+    throw new ResultObjectError({
+      type: "missing_student",
+      message: `Missing student in Canvas ${result.Student.Uid} (${result.Student.Fornamn} ${result.Student.Efternamn} )`,
+    });
+  }
+
+  let ladokGrade;
+  if (submission?.grade) {
+    ladokGrade = await getLadokGrade(
+      result.Rapporteringskontext.BetygsskalaID,
+      submission.grade
+    );
+  }
+  if (!ladokGrade)
+    throw new ResultObjectError({
+      type: "missing_grade",
+      message: "No ladok grade found for this submission",
+    });
+
+  const commonData = {
+    Betygsgrad: ladokGrade.ID,
+    BetygsskalaID: result.Rapporteringskontext.BetygsskalaID,
+    Examinationsdatum: examinationDate,
+  };
+
+  if (actionType === "create") {
+    return {
+      ...commonData,
+      Uid: result.Uid, // TODO: Why is this different from the update object and same as below?
+      StudieresultatUID: result.Uid,
+      UtbildningsinstansUID: moduleId,
+    };
+  }
+
+  if (actionType === "update") {
+    const existingResult = result.ResultatPaUtbildningar.find(
+      (rpu) => rpu.Arbetsunderlag?.UtbildningsinstansUID === moduleId
+    );
+
+    // This submission already exists (NOOP)
+    if (existingResult.Arbetsunderlag.Betygsgrad === ladokGrade.ID)
+      throw new ResultObjectError({
+        type: "result_exists",
+        message: "This result already exists in LADOK",
+      });
+
+    return {
+      ...commonData,
+      Uid: result.Student.Uid,
+      ResultatUID: existingResult.Arbetsunderlag.Uid,
+      SenasteResultatandring:
+        existingResult.Arbetsunderlag.SenasteResultatandring,
+    };
+  }
+
+  throw new Error(
+    `Unknown actionType "${actionType}", should match [create|update]`
+  );
+}
+
 /**
  * @param courseId
  * @param examinationRoundId
@@ -151,6 +238,8 @@ async function transferResults(
 
   const canvas = CanvasAPI(`${process.env.CANVAS_HOST}/api/v1`, token);
 
+  // 1. Get in data from Canvas and LADOK
+
   const submissions = await canvas
     .list(`/courses/${courseId}/assignments/${assignmentId}/submissions`, {
       include: ["user"],
@@ -158,7 +247,8 @@ async function transferResults(
     .toArray()
     .catch(canvasGenericErrorHandler);
 
-  const { body: user } = await canvas
+  // User performing transfer of grades
+  const { body: submittingUser } = await canvas
     .get("/users/self")
     .catch(canvasGenericErrorHandler);
 
@@ -173,121 +263,117 @@ async function transferResults(
     .filter((s) => s.integration_id)
     .map((s) => s.integration_id);
 
-  const transferObject1 = {
-    LarosateID: process.env.LADOK_KTH_LAROSATE_ID,
-    Resultat: [],
-  };
-
-  const transferObject2 = {
-    Resultat: [],
-  };
-
   const grades = submissions.map((s) => ({
     name: s.user.sortable_name,
     id: s.user.integration_id,
     grade: s.grade,
   }));
 
-  const results1 = await searchLadokResults(moduleId, courseRounds, "create");
-  const results2 = await searchLadokResults(moduleId, courseRounds, "update");
+  // New results to be created
+  const resultsCreate = await searchLadokResults(
+    moduleId,
+    courseRounds,
+    "create"
+  );
 
-  log.info(`Found ${results1.length} results in Ladok for Create`);
-  log.info(`Found ${results2.length} results in Ladok for Update`);
+  // Existing results to be updated
+  const resultsUpdate = await searchLadokResults(
+    moduleId,
+    courseRounds,
+    "update"
+  );
 
-  for (const result of results1) {
-    const submission = grades.find((s) => s.id === result.Student.Uid);
-    if (!submission) {
-      log.info(
-        `Missing student in Canvas ${result.Student.Uid} (${result.Student.Fornamn} ${result.Student.Efternamn} )`
-      );
-      continue;
-    }
+  log.info(`Found ${resultsCreate.length} results in Ladok for Create`);
+  log.info(`Found ${resultsUpdate.length} results in Ladok for Update`);
 
-    const ladokGrade =
-      submission &&
-      submission.grade &&
-      (await getLadokGrade(
-        result.Rapporteringskontext.BetygsskalaID,
-        submission.grade
-      ));
+  // 2. Process results and send create/update instructions to LADOK
+  const resultsForFunctionReturnValue = [];
 
-    if (ladokGrade && ladokGrade.ID) {
-      transferObject1.Resultat.push({
-        Uid: result.Uid,
-        StudieresultatUID: result.Uid,
-        UtbildningsinstansUID: moduleId,
-        Betygsgrad: ladokGrade.ID,
-        BetygsskalaID: result.Rapporteringskontext.BetygsskalaID,
-        Examinationsdatum: examinationDate,
+  const commonParams = {
+    grades,
+    moduleId,
+    examinationDate,
+  };
+
+  // **** CREATE ****
+  const resultsForLogCreated = [];
+  for (const result of resultsCreate) {
+    let resultObj;
+    try {
+      resultObj = await createLadokResultObject({
+        actionType: "create",
+        result,
+        ...commonParams,
       });
+    } catch (err) {
+      if (err instanceof ResultObjectError) {
+        log.info(err, err.message);
+        // Skip this user due to error
+        continue;
+      } else {
+        throw err;
+      }
     }
+    resultsForLogCreated.push(resultObj);
+
+    const res = await ladokGot
+      .post("/resultat/studieresultat/skapa", {
+        body: {
+          LarosateID: process.env.LADOK_KTH_LAROSATE_ID,
+          Resultat: [resultObj],
+        },
+      })
+      .catch(ladokGenericErrorHandler);
+    resultsForFunctionReturnValue.push(res.body.Resultat);
   }
 
-  for (const result of results2) {
-    const submission = grades.find((s) => s.id === result.Student.Uid);
-    if (!submission) {
-      log.info(
-        `Missing student in Canvas ${result.Student.Uid} (${result.Student.Fornamn} ${result.Student.Efternamn} )`
-      );
-      continue;
-    }
-
-    const ladokGrade =
-      submission &&
-      submission.grade &&
-      (await getLadokGrade(
-        result.Rapporteringskontext.BetygsskalaID,
-        submission.grade
-      ));
-
-    const existingResult = result.ResultatPaUtbildningar.find(
-      (rpu) =>
-        rpu.Arbetsunderlag &&
-        rpu.Arbetsunderlag.UtbildningsinstansUID === moduleId
-    );
-
-    if (
-      ladokGrade &&
-      existingResult.Arbetsunderlag.Betygsgrad !== ladokGrade.ID
-    ) {
-      transferObject2.Resultat.push({
-        Uid: result.Student.Uid,
-        ResultatUID: existingResult.Arbetsunderlag.Uid,
-        Betygsgrad: ladokGrade.ID,
-        BetygsskalaID: result.Rapporteringskontext.BetygsskalaID,
-        Examinationsdatum: examinationDate,
-        SenasteResultatandring:
-          existingResult.Arbetsunderlag.SenasteResultatandring,
+  // **** UPDATE ****
+  const resultsForLogUpdated = [];
+  for (const result of resultsUpdate) {
+    let resultObj;
+    try {
+      resultObj = await createLadokResultObject({
+        actionType: "update",
+        result,
+        ...commonParams,
       });
+    } catch (err) {
+      if (err instanceof ResultObjectError) {
+        log.info(err, err.message);
+        // Skip this user due to error
+        continue;
+      } else {
+        throw err;
+      }
     }
+    resultsForLogUpdated.push(resultObj);
+
+    const res = await ladokGot
+      .put("/resultat/studieresultat/uppdatera", {
+        body: {
+          Resultat: [resultObj],
+        },
+      })
+      .catch(ladokGenericErrorHandler);
+    resultsForFunctionReturnValue.push(res.body.Resultat);
   }
 
+  // 3. Log and return results of operation
   const dataLog = {
     transfer_timestamp: Date.now(),
-    user_canvas_id: user.id,
+    user_canvas_id: submittingUser.id,
     from_course_id: courseId,
     from_assignment_id: assignmentId,
 
     to_module: moduleId,
     examination_date: examinationDate,
-    new_grades: transferObject1.Resultat,
-    updated_grades: transferObject2.Resultat,
+    new_grades: resultsForLogCreated,
+    updated_grades: resultsForLogUpdated,
   };
   mongo.write(dataLog);
 
-  const r1 = await ladokGot
-    .post("/resultat/studieresultat/skapa", {
-      body: transferObject1,
-    })
-    .catch(ladokGenericErrorHandler);
-
-  const r2 = await ladokGot
-    .put("/resultat/studieresultat/uppdatera", {
-      body: transferObject2,
-    })
-    .catch(ladokGenericErrorHandler);
-
-  return [...r1.body.Resultat, ...r2.body.Resultat];
+  // Return list of results from LADOK
+  return resultsForFunctionReturnValue;
 }
 
 module.exports = {


### PR DESCRIPTION
This update contains a refactor of the API transferResults() method for readability.

Adds feature to transfer results where one or more students are blocked from transferring results to LADOK.

This is achieved by transferring results one-by-one, instead of batch updates, and returning the failed transfers to the web client to allow the UI to present them in a table on the result page. A yellow info-box is shown, alerting the user that this was a partial success.

No specific tests where added, but a separate card about this has been created in the backlog.